### PR TITLE
Updated User Story 1 to count unique specimens per project

### DIFF
--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -19,7 +19,7 @@ group by 1;
 select p.uuid                                   as project_uuid,
        p.json->'project_core'->>'project_title' as project_title,
        s.json->'organ'->>'text'                 as organ,
-       count(distinct(s.uuid))                  as specimen_uuid
+       count(distinct(s.uuid))                  as specimen_count
 from bundles as b
        join specimen_from_organisms as s on s.fqid = ANY(b.file_fqids)
        join projects as p on p.fqid = ANY(b.file_fqids)

--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -4,7 +4,7 @@ Query user stories taken from the [Blue Box Queries
 Table](https://docs.google.com/spreadsheets/d/1PBMrc0oql4gPpH_cQMqlf7ASNMwePRQZNCutxeSFze8/edit#gid=0)
 
 ## 1
-Please give me a list of all the contact emails and titles for all the projects, and how many samples (specimens) and files each project has.
+Please give me a list of all the contact emails and titles for all the projects, and how many samples (specimens) and sequencing files each project has.
 
 ### emails
 ```sql
@@ -24,6 +24,18 @@ from bundles as b
        join specimen_from_organisms as s on s.fqid = ANY(b.file_fqids)
        join projects as p on p.fqid = ANY(b.file_fqids)
 group by 1, 2, 3;
+```
+
+### data (sequence) file count per project
+```sql
+select p.uuid                                   as project_uuid,
+       p.json->'project_core'->>'project_title' as project_title,
+       count(distinct(f.uuid))                  as file_count
+from bundles as b
+       join files as f on f.fqid = ANY(b.file_fqids)
+       join projects as p on p.fqid = ANY(b.file_fqids)
+WHERE f.module_id = 87 /* sequence_file_*.json */
+group by 1,2;
 ```
 
 ## 2

--- a/USER_STORIES.md
+++ b/USER_STORIES.md
@@ -4,7 +4,7 @@ Query user stories taken from the [Blue Box Queries
 Table](https://docs.google.com/spreadsheets/d/1PBMrc0oql4gPpH_cQMqlf7ASNMwePRQZNCutxeSFze8/edit#gid=0)
 
 ## 1
-Please give me a list of all the contact emails and titles for all the projects, and how many samples and files each has.
+Please give me a list of all the contact emails and titles for all the projects, and how many samples (specimens) and files each project has.
 
 ### emails
 ```sql
@@ -14,16 +14,16 @@ from projects as p,
 group by 1;
 ```
 
-### counts
+### specimen count per project
 ```sql
 select p.uuid                                   as project_uuid,
        p.json->'project_core'->>'project_title' as project_title,
        s.json->'organ'->>'text'                 as organ,
-       count(1)
+       count(distinct(s.uuid))                  as specimen_uuid
 from bundles as b
        join specimen_from_organisms as s on s.fqid = ANY(b.file_fqids)
        join projects as p on p.fqid = ANY(b.file_fqids)
-group by 1, 2, 3
+group by 1, 2, 3;
 ```
 
 ## 2


### PR DESCRIPTION
If a project takes more than 1 cell suspensions per specimen, the specimens will be counted more than once, one per cell suspension. In order to get the count of specimens per project, the query needs to do a `distinct` on the specimen UUID.

Added a query to get sequence data files per project.