### PR TITLE
add a lifecycle rule per env folder for s3 bucket

### DIFF
--- a/terraform/modules/query-service-infra/bucket.tf
+++ b/terraform/modules/query-service-infra/bucket.tf
@@ -4,7 +4,39 @@ resource "aws_s3_bucket" "query-service" {
   force_destroy = "false"
   acceleration_status = "Enabled"
   lifecycle_rule {
-    prefix  = "${var.deployment_stage}/query_results/"
+    prefix  = "predev/query_results/"
+    enabled = true
+
+    expiration {
+      days = 90
+    }
+  }
+  lifecycle_rule {
+    prefix  = "dev/query_results/"
+    enabled = true
+
+    expiration {
+      days = 90
+    }
+  }
+  lifecycle_rule {
+    prefix  = "integration/query_results/"
+    enabled = true
+
+    expiration {
+      days = 90
+    }
+  }
+  lifecycle_rule {
+    prefix  = "staging/query_results/"
+    enabled = true
+
+    expiration {
+      days = 90
+    }
+  }
+  lifecycle_rule {
+    prefix  = "prod/query_results/"
     enabled = true
 
     expiration {


### PR DESCRIPTION
We are using lifecycle rules to delete all query results that are older than 90 days. 

Because the results are in the same s3 bucket namespaced by env (excluding prod) and we are determining what to delete based on the prefix there needs to be a lifecycle rule per env 

Note the gitlab infra pipeline will fail due to another open pr that is updating the teraform