### PR TITLE
Simplify secret generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,11 @@ env:
   global:
   - AWS_DEFAULT_REGION=us-east-1
   - AWS_DEFAULT_OUTPUT=json
+  - TERRAFORM_VERSION=0.11.13
 
 install:
+  - curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+  - sudo unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin
   - pip install -r requirements-dev.txt
 
 before_script:

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ clean:
 lint:
 	flake8 *.py $(APP_NAME) tests
 	mypy $(APP_NAME) --ignore-missing-imports
+	cd tests/terraform; terraform init; terraform validate
 
 test: lint
 	coverage run --source $(APP_NAME) -m unittest discover --start-directory tests --top-level-directory . --verbose

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ install-webhooks:
 	python -m $(APP_NAME).webhooks install --callback-url=$$($(MAKE) get-tf-output | jq -r .api_endpoint_url.value)bundles/event
 
 install-secrets:
-	python -c 'import secrets; print(secrets.token_urlsafe(32), end="")' | aws secretsmanager put-secret-value --secret-id $(APP_NAME)/$(STAGE)/postgresql/password --secret-string file:///dev/stdin
+	aws secretsmanager put-secret-value --secret-id $(APP_NAME)/$(STAGE)/postgresql/password --secret-string $$(python -c 'import secrets; print(secrets.token_urlsafe(32))')
 	aws rds modify-db-cluster --db-cluster-identifier dcpquery-dev --master-user-password $$(aws secretsmanager get-secret-value --secret-id $(APP_NAME)/$(STAGE)/postgresql/password | jq -r .SecretString) --apply-immediately
 
 build-chalice-config:

--- a/tests/terraform/lint.tf
+++ b/tests/terraform/lint.tf
@@ -1,0 +1,3 @@
+module "dcpquery_lint" {
+  source = "../../terraform"
+}


### PR DESCRIPTION
Make does not expose subshell results, and I think the runtime is too short for the process args exposure be a problem, so we don't have to pass the secret on stdin.