### PR TITLE
Use default Terraform AWS credentials

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ prune:
 get-tf-output:
 	@terraform output -module=$(APP_NAME) -json
 
+# init-tf prepares the repo for Terraform commands. It assembles the partial S3 backend config as a JSON file, `aws_config.json`.
+# This file is referenced by the TF_CLI_ARGS_init environment variable, which is set by running `source environment`.
 init-tf:
 	-rm -f .terraform/*.tfstate
 	jq -n ".region=env.AWS_DEFAULT_REGION | .bucket=env.TF_S3_BUCKET | .key=env.APP_NAME+env.STAGE" > .terraform/aws_config.json

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ clean:
 lint:
 	flake8 *.py $(APP_NAME) tests
 	mypy $(APP_NAME) --ignore-missing-imports
-	cd tests/terraform; terraform init; terraform validate
+	unset TF_CLI_ARGS_init; cd tests/terraform; terraform init; terraform validate
 
 test: lint
 	coverage run --source $(APP_NAME) -m unittest discover --start-directory tests --top-level-directory . --verbose

--- a/Makefile
+++ b/Makefile
@@ -58,15 +58,12 @@ package:
 prune:
 	zip -dr dist/deployment.zip botocore/data/ec2* cryptography* swagger_ui_bundle/vendor/swagger-ui-2* connexion/vendor/swagger-ui*
 
-get-config:
-	@python -c $(GET_CREDS) | jq ".region=env.AWS_DEFAULT_REGION | .bucket=env.TF_S3_BUCKET | .key=env.APP_NAME+env.STAGE"
-
 get-tf-output:
 	@terraform output -module=$(APP_NAME) -json
 
 init-tf:
 	-rm -f .terraform/*.tfstate
-	$(MAKE) --no-print-directory get-config > .terraform/aws_config.json
+	jq -n ".region=env.AWS_DEFAULT_REGION | .bucket=env.TF_S3_BUCKET | .key=env.APP_NAME+env.STAGE" > .terraform/aws_config.json
 	terraform init
 
 destroy: init-tf
@@ -126,5 +123,5 @@ requirements.txt requirements-dev.txt : %.txt : %.txt.in
 
 requirements-dev.txt : requirements.txt.in
 
-.PHONY: deploy init-secrets install-webhooks install-secrets build-chalice-config package get-config get-tf-output init-tf init-db destroy
+.PHONY: deploy init-secrets install-webhooks install-secrets build-chalice-config package get-tf-output init-tf init-db destroy
 .PHONY: clean lint test fetch init-db load load-test-data update-lambda get-logs refresh-all-requirements

--- a/environment
+++ b/environment
@@ -26,6 +26,9 @@ TFSTATE_FILE=.terraform/remote.tfstate
 TF_CLI_ARGS_output="--state ${TFSTATE_FILE}"
 TF_CLI_ARGS_init="--backend-config ${APP_HOME}/.terraform/aws_config.json"
 
+# See https://github.com/terraform-providers/terraform-provider-aws/issues/1184
+AWS_SDK_LOAD_CONFIG=1
+
 if [[ -z "$AWS_DEFAULT_REGION" ]]; then
     AWS_DEFAULT_REGION=$(aws configure get region)
 fi
@@ -39,5 +42,4 @@ EXPORT_ENV_VARS_TO_TF="APP_NAME STAGE OWNER BUNDLE_EVENTS_QUEUE_NAME ASYNC_QUERI
 EXPORT_ENV_VARS_TO_LAMBDA=$EXPORT_ENV_VARS_TO_TF
 set +a
 
-make --no-print-directory get-config > "${APP_HOME}/.terraform/aws_config.json"
 for v in $EXPORT_ENV_VARS_TO_TF; do echo "variable $v { default = \"${!v}\" }"; done > terraform/variables.tf

--- a/main.tf
+++ b/main.tf
@@ -3,16 +3,8 @@ terraform {
   }
 }
 
-data "external" "aws_config" {
-  program = ["make", "get-config"]
-}
-
 provider "aws" {
   version = "~> 2.4"
-  access_key = "${data.external.aws_config.result.access_key}"
-  secret_key = "${data.external.aws_config.result.secret_key}"
-  token = "${data.external.aws_config.result.token}"
-  region = "${data.external.aws_config.result.region}"
 }
 
 provider "external" {


### PR DESCRIPTION
This uses the `AWS_SDK_LOAD_CONFIG` environment variable to induce the AWS Go SDK to ingest credentials in a way consistent with other AWS utilities. This eliminates the need for the credentials import shim TF external data source.