### PR TITLE
Use SQLAlchemy Mutable extension

### DIFF
--- a/dcpquery/db/__init__.py
+++ b/dcpquery/db/__init__.py
@@ -4,9 +4,10 @@ This module provides a SQLAlchemy-based database schema for the DCP Query Servic
 import enum
 import os, sys, argparse, json, logging, typing
 
-from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, String, DateTime, Integer, ForeignKey, Table, Enum, exc as sqlalchemy_exceptions, text
 from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext.mutable import MutableDict
 from sqlalchemy.orm import relationship, sessionmaker
 
 from .. import config
@@ -37,8 +38,8 @@ class Bundle(DCPQueryModelHelper, SQLAlchemyBase):
     fqid = Column(String, primary_key=True, unique=True, nullable=False)
     uuid = Column(UUID, nullable=False)
     version = Column(DateTime, nullable=False)
-    manifest = Column(JSONB)
-    aggregate_metadata = Column(JSONB)
+    manifest = Column(MutableDict.as_mutable(JSONB))
+    aggregate_metadata = Column(MutableDict.as_mutable(JSONB))
     files = relationship("File", secondary='bundle_file_links')
 
 
@@ -56,7 +57,7 @@ class File(DCPQueryModelHelper, SQLAlchemyBase):
     version = Column(DateTime, nullable=False)
     schema_type_id = Column(Integer, ForeignKey("schema_types.id"))
     schema_type = relationship("SchemaType", back_populates="files")
-    body = Column(JSONB)
+    body = Column(MutableDict.as_mutable(JSONB))
     content_type = Column(String)
     size = Column(Integer)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -25,7 +25,7 @@ def load_fixture(fixture_file):
 
 vx_bundle_fqid = '0c8d7f15-47c2-42c2-83de-47ae48e1eae1.2018-09-06T190237.485774Z'
 vx_bundle_manifest = load_fixture('vx_bundle.json')
-vx_bundle_aggregate_md = load_fixture('vx_bundle_document.json')
+vx_bundle_aggregate_md = json.loads(load_fixture('vx_bundle_document.json'))
 fast_query_mock_result = json.loads(load_fixture('fast_query_mock_result.json'))
 fast_query_expected_results = json.loads(load_fixture('fast_query_expected_results.json'))
 mock_links = json.loads(load_fixture('process_links.json'))


### PR DESCRIPTION
This allows us to load ORM proxy objects, modify their JSONB column
docs as Python mappings, and have the session automatically add those
modifications to the pending updates.