### PR TITLE
add unique constraint to process_file_connection_table

### DIFF
--- a/dcpquery/_config.py
+++ b/dcpquery/_config.py
@@ -72,7 +72,7 @@ class DCPQueryConfig:
                 db_host = AwsSecret(db_host_secret_name).value.strip()
             db_name = self.app_name
             self._db = sqlalchemy.create_engine(f"postgresql+psycopg2://{db_user}:{db_password}@{db_host}/{db_name}",
-                                                **self._db_engine_params)
+                                                implicit_returning=False, **self._db_engine_params)
 
             if self._db_ignore_insert_conflicts:
                 @sqlalchemy.event.listens_for(self._db, 'before_cursor_execute', retval=True)

--- a/dcpquery/db/__init__.py
+++ b/dcpquery/db/__init__.py
@@ -4,8 +4,8 @@ This module provides a SQLAlchemy-based database schema for the DCP Query Servic
 import enum
 import os, sys, argparse, json, logging, typing
 
-from sqlalchemy import Column, String, DateTime, Integer, ForeignKey, Table, Enum, exc as sqlalchemy_exceptions, text, \
-    UniqueConstraint
+from sqlalchemy import (Column, String, DateTime, Integer, ForeignKey, Table, Enum, exc as sqlalchemy_exceptions,
+                        UniqueConstraint)
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.mutable import MutableDict
@@ -107,9 +107,8 @@ class ProcessFileLink(SQLAlchemyBase):
     process = relationship(Process)
     file_uuid = Column(UUID)
 
-    __table_args__ = (UniqueConstraint
-                      ('process_uuid', 'process_file_connection_type', 'file_uuid',
-                       name='process_file_connection_type_uc'),)
+    __table_args__ = (UniqueConstraint(
+        'process_uuid', 'process_file_connection_type', 'file_uuid', name='process_file_connection_type_uc'),)
 
     def get_most_recent_file(self):
         return config.db_session.query(File).filter(File.uuid == self.file_uuid).order_by(File.version.desc()).first()
@@ -124,58 +123,116 @@ class ProcessProcessLink(SQLAlchemyBase):
     child_process = relationship(Process, foreign_keys=[child_process_uuid])
 
 
-def init_database(dry_run=True):
-    from sqlalchemy_utils import database_exists, create_database
+class DCPQueryDBManager:
+    def init_db(self, dry_run=True):
+        from sqlalchemy_utils import database_exists, create_database
 
-    logger.info("Initializing database at %s", repr(config.db.url))
-    if not database_exists(config.db.url):
-        logger.info("Creating database")
-        create_database(config.db.url)
-    logger.info("Initializing database")
+        logger.info("Initializing database at %s", repr(config.db.url))
+        if not database_exists(config.db.url):
+            logger.info("Creating database")
+            create_database(config.db.url)
+        logger.info("Initializing database")
 
-    if dry_run:
-        config._db_engine_params.update(strategy="mock", executor=lambda sql, *args, **kwargs: print(sql))
-    SQLAlchemyBase.metadata.create_all(config.db)
-    create_recursive_process_functions_in_db()
+        if dry_run:
+            config._db_engine_params.update(strategy="mock", executor=lambda sql, *args, **kwargs: print(sql))
+        SQLAlchemyBase.metadata.create_all(config.db)
+        self.create_recursive_functions_in_db()
+        self.create_upsert_rules_in_db()
 
+    process_file_link_ignore_duplicate_rule_sql = """
+        CREATE OR REPLACE RULE process_file_join_table_ignore_duplicate_inserts AS
+            ON INSERT TO process_file_join_table
+                WHERE EXISTS (
+                  SELECT 1
+                FROM process_file_join_table
+                WHERE process_uuid = NEW.process_uuid
+                AND process_file_connection_type=NEW.process_file_connection_type
+                AND file_uuid=NEW.file_uuid
+            )
+            DO INSTEAD NOTHING;
+    """
+    file_ignore_duplicate_rule_sql = """
+        CREATE OR REPLACE RULE file_table_ignore_duplicate_inserts AS
+            ON INSERT TO files
+                WHERE EXISTS (
+                  SELECT 1
+                FROM files
+                WHERE fqid = NEW.fqid
+            )
+            DO INSTEAD NOTHING;
+    """
+    bundle_ignore_duplicate_rule_sql = """
+        CREATE OR REPLACE RULE bundle_table_ignore_duplicate_inserts AS
+            ON INSERT TO bundles
+                WHERE EXISTS (
+                  SELECT 1
+                FROM bundles
+                WHERE fqid = NEW.fqid
+            )
+            DO INSTEAD NOTHING;
+    """
+    bundle_file_link_ignore_duplicate_rule_sql = """
+        CREATE OR REPLACE RULE bundle_file_join_table_ignore_duplicate_inserts AS
+            ON INSERT TO bundle_file_links
+                WHERE EXISTS (
+                  SELECT 1
+                FROM bundle_file_links
+                WHERE bundle_fqid = NEW.bundle_fqid
+                AND file_fqid = NEW.file_fqid
+            )
+            DO INSTEAD NOTHING;
+    """
+    process_ignore_duplicate_rule_sql = """
+        CREATE OR REPLACE RULE process_table_ignore_duplicate_inserts AS
+            ON INSERT TO processes
+                WHERE EXISTS (
+                  SELECT 1
+                FROM processes
+                WHERE process_uuid = NEW.process_uuid
+            )
+            DO INSTEAD NOTHING;
+    """
 
-def create_recursive_process_functions_in_db():
-    config.db_session.execute("""
-                    CREATE or REPLACE FUNCTION get_all_children(IN parent_process_uuid UUID)
-                        RETURNS TABLE(child_process UUID) as $$
-                          WITH RECURSIVE recursive_table AS (
-                            SELECT child_process_uuid FROM process_join_table
-                            WHERE parent_process_uuid=$1
-                            UNION
-                            SELECT process_join_table.child_process_uuid FROM process_join_table
-                            INNER JOIN recursive_table
-                            ON process_join_table.parent_process_uuid = recursive_table.child_process_uuid)
-                        SELECT * from recursive_table;
-                        $$ LANGUAGE SQL;
+    get_all_children_function_sql = """
+        CREATE or REPLACE FUNCTION get_all_children(IN parent_process_uuid UUID)
+            RETURNS TABLE(child_process UUID) as $$
+              WITH RECURSIVE recursive_table AS (
+                SELECT child_process_uuid FROM process_join_table
+                WHERE parent_process_uuid=$1
+                UNION
+                SELECT process_join_table.child_process_uuid FROM process_join_table
+                INNER JOIN recursive_table
+                ON process_join_table.parent_process_uuid = recursive_table.child_process_uuid)
+            SELECT * from recursive_table;
+            $$ LANGUAGE SQL;
+    """
+    get_all_parents_function_sql = """
+        CREATE or REPLACE FUNCTION get_all_parents(IN child_process_uuid UUID)
+            RETURNS TABLE(parent_process UUID) as $$
+              WITH RECURSIVE recursive_table AS (
+                SELECT parent_process_uuid FROM process_join_table
+                WHERE child_process_uuid=$1
+                UNION
+                SELECT process_join_table.parent_process_uuid FROM process_join_table
+                INNER JOIN recursive_table
+                ON process_join_table.child_process_uuid = recursive_table.parent_process_uuid)
+            SELECT * from recursive_table;
+            $$ LANGUAGE SQL;
+    """
 
-                    CREATE or REPLACE FUNCTION get_all_parents(IN child_process_uuid UUID)
-                        RETURNS TABLE(parent_process UUID) as $$
-                          WITH RECURSIVE recursive_table AS (
-                            SELECT parent_process_uuid FROM process_join_table
-                            WHERE child_process_uuid=$1
-                            UNION
-                            SELECT process_join_table.parent_process_uuid FROM process_join_table
-                            INNER JOIN recursive_table
-                            ON process_join_table.child_process_uuid = recursive_table.parent_process_uuid)
-                        SELECT * from recursive_table;
-                        $$ LANGUAGE SQL;
-                    CREATE OR REPLACE RULE db_table_ignore_duplicate_inserts AS
-                        ON INSERT TO process_file_join_table
-                        WHERE EXISTS (
-                            SELECT 1
-                            FROM process_file_join_table
-                            WHERE process_uuid = NEW.process_uuid
-                            AND process_file_connection_type=NEW.process_file_connection_type
-                            AND file_uuid=NEW.file_uuid
-                        )
-                        DO INSTEAD NOTHING;
-                    """)
-    config.db_session.commit()
+    def create_upsert_rules_in_db(cls):
+        config.db_session.execute(
+            cls.bundle_file_link_ignore_duplicate_rule_sql + cls.bundle_ignore_duplicate_rule_sql
+        )
+        config.db_session.execute(
+            cls.process_file_link_ignore_duplicate_rule_sql + cls.process_ignore_duplicate_rule_sql
+        )
+        config.db_session.execute(cls.file_ignore_duplicate_rule_sql)
+        config.db_session.commit()
+
+    def create_recursive_functions_in_db(cls):
+        config.db_session.execute(cls.get_all_children_function_sql + cls.get_all_parents_function_sql)
+        config.db_session.commit()
 
 
 def run_query(query, rows_per_page=100):

--- a/dcpquery/db/__main__.py
+++ b/dcpquery/db/__main__.py
@@ -8,7 +8,7 @@ from dcplib.etl import DSSExtractor
 
 from .. import config
 from ..etl import transform_bundle, load_bundle
-from . import init_database
+from . import DCPQueryDBManager
 
 logging.basicConfig(level=logging.INFO)
 parser = argparse.ArgumentParser(description=__doc__)
@@ -21,7 +21,7 @@ if args.db == "remote":
     config.local_mode = False
 
 if args.action == "init":
-    init_database(dry_run=args.dry_run)
+    DCPQueryDBManager().init_db(dry_run=args.dry_run)
 elif args.action in {"load", "load-test"}:
     if args.action == "load":
         extractor_args = {}  # type: ignore

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -214,7 +214,6 @@ class TestDBRules(unittest.TestCase):
         config.db_session.execute("DROP RULE bundle_file_join_table_ignore_duplicate_inserts ON bundle_file_links;")
         config.db_session.commit()
 
-    #
     @classmethod
     def tearDownClass(cls):
         config.db_session.rollback()


### PR DESCRIPTION
## Need
- prevent duplicates from being added to the process_file_connection_table

## Approach
- add unique constraint to process_file_connection_table
- handle possible duplicate key errors with a rule
- prevent implicit return from breaking rule

## Testing
- tested manually in db

## Todo 
- reinit db after pr for adding file extension is merged into this one