### PR TITLE
Add drop database helper to database manager script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ fetch:
 init-db:
 	python -m $(APP_NAME).db init
 
+drop-db:
+	python -m $(APP_NAME).db drop
+
 load: init-db
 	python -m $(APP_NAME).db load
 

--- a/dcpquery/db/__main__.py
+++ b/dcpquery/db/__main__.py
@@ -28,7 +28,7 @@ default_test_query = {
 
 config.configure_logging()
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument("action", choices={"init", "load", "load-test", "connect"})
+parser.add_argument("action", choices={"init", "drop", "load", "load-test", "connect"})
 parser.add_argument("--db", choices={"local", "remote"}, default="local")
 parser.add_argument("--dry-run", action="store_true", help="Print commands that would be executed without running them")
 parser.add_argument("--test-query", type=json.loads, default=default_test_query)
@@ -39,6 +39,8 @@ if args.db == "remote":
 
 if args.action == "init":
     DCPQueryDBManager().init_db(dry_run=args.dry_run)
+elif args.action == "drop":
+    DCPQueryDBManager().drop_db(dry_run=args.dry_run)
 elif args.action in {"load", "load-test"}:
     if args.action == "load":
         extractor_args = {}  # type: ignore

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -306,5 +306,15 @@ class TestDBRules(unittest.TestCase):
         config.db_session.commit()
 
 
+class TestDatabaseUtils(unittest.TestCase):
+    def test_init_db(self):
+        DCPQueryDBManager().init_db(dry_run=True)
+        DCPQueryDBManager().init_db()  # dry_run is True by default
+
+    def test_drop_db(self):
+        DCPQueryDBManager().drop_db(dry_run=True)
+        DCPQueryDBManager().drop_db()  # dry_run is True by default
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Also:

- Name object pointer self instead of cls on adjacent object methods

- Hoist class variable declarations to the top of class declaration