### PR TITLE
Terraform: manage webhook auth config secret object, but not value

### DIFF
--- a/terraform/api.tf
+++ b/terraform/api.tf
@@ -94,3 +94,7 @@ resource "aws_s3_bucket" "query_service_bucket" {
     }
   }
 }
+
+resource "aws_secretsmanager_secret" "webhook_auth_config" {
+  name = "${var.APP_NAME}/${var.STAGE}/webhook-auth-config"
+}


### PR DESCRIPTION
Found this gap when deploying integration/staging.