### PR TITLE
process bundle deletion events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ lint:
 test: lint docs build-chalice-config unit-test migration-test
 
 unit-test: load-test-data
-	coverage run --source $(APP_NAME) -m unittest discover --start-directory tests/unit --top-level-directory . --verbose
+	coverage run --timid --source $(APP_NAME) -m unittest discover --start-directory tests/unit --top-level-directory . --verbose
 
 integration-test:
 	python -m unittest discover --start-directory tests/integration --top-level-directory . --verbose

--- a/dcpquery/db/__init__.py
+++ b/dcpquery/db/__init__.py
@@ -2,14 +2,15 @@
 This module provides a SQLAlchemy-based database schema for the DCP Query Service.
 """
 import enum
-import os, sys, argparse, json, logging, typing
+import logging, typing
 
-from sqlalchemy import (Column, String, DateTime, Integer, ForeignKey, Table, Enum, exc as sqlalchemy_exceptions,
+from sqlalchemy import (Column, String, DateTime, Integer, ForeignKey, Enum, exc as sqlalchemy_exceptions,
                         UniqueConstraint, BigInteger)
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.mutable import MutableDict
-from sqlalchemy.orm import relationship, sessionmaker
+from sqlalchemy.orm import relationship
+from typing import List
 
 from .. import config
 from ..exceptions import DCPQueryError, QueryTimeoutError
@@ -44,6 +45,10 @@ class Bundle(DCPQueryModelHelper, SQLAlchemyBase):
         delete_q = cls.__table__.delete().where(cls.fqid.in_(bundle_fqids))
         config.db_session.execute(delete_q)
 
+    @classmethod
+    def select_bundle(cls, bundle_fqid):
+        return config.db_session.query(cls).filter(cls.fqid == bundle_fqid).one_or_none()
+
 
 class DCPMetadataSchemaType(SQLAlchemyBase):
     __tablename__ = 'dcp_metadata_schema_types'
@@ -64,6 +69,10 @@ class File(DCPQueryModelHelper, SQLAlchemyBase):
     extension = Column(String)
 
     @classmethod
+    def select_file(cls, file_fqid):
+        return config.db_session.query(cls).filter(cls.fqid == file_fqid).one_or_none()
+
+    @classmethod
     def delete_files(cls, file_fqids):
         delete_q = cls.__table__.delete().where(cls.fqid.in_(file_fqids))
         config.db_session.execute(delete_q)
@@ -78,17 +87,22 @@ class BundleFileLink(SQLAlchemyBase):
     name = Column(String, nullable=False)
 
     @classmethod
-    def delete_links_for_bundles(cls, bundle_fqids):
+    def delete_links_for_bundles(cls, bundle_fqids: List[str]):
         delete_q = cls.__table__.delete().where(cls.bundle_fqid.in_(bundle_fqids))
         config.db_session.execute(delete_q)
 
     @classmethod
-    def select_links_for_bundle_fqids(cls, bundle_fqids):
+    def delete_links_for_files(cls, file_fqids: List[str]):
+        delete_q = cls.__table__.delete().where(cls.file_fqid.in_(file_fqids))
+        config.db_session.execute(delete_q)
+
+    @classmethod
+    def select_links_for_bundle_fqids(cls, bundle_fqids: List[str]):
         links = cls.__table__.select().where(cls.bundle_fqid.in_(bundle_fqids))
         return config.db_session.execute(links)
 
     @classmethod
-    def select_links_for_file_fqids(cls, file_fqids):
+    def select_links_for_file_fqids(cls, file_fqids: List[str]):
         links = cls.__table__.select().where(cls.file_fqid.in_(file_fqids))
         return config.db_session.execute(links)
 

--- a/dcpquery/db/__init__.py
+++ b/dcpquery/db/__init__.py
@@ -39,6 +39,11 @@ class Bundle(DCPQueryModelHelper, SQLAlchemyBase):
     aggregate_metadata = Column(MutableDict.as_mutable(JSONB))
     files = relationship("File", secondary='bundle_file_links')
 
+    @classmethod
+    def delete_bundles(cls, bundle_fqids):
+        delete_q = cls.__table__.delete().where(cls.fqid.in_(bundle_fqids))
+        config.db_session.execute(delete_q)
+
 
 class DCPMetadataSchemaType(SQLAlchemyBase):
     __tablename__ = 'dcp_metadata_schema_types'
@@ -58,6 +63,11 @@ class File(DCPQueryModelHelper, SQLAlchemyBase):
     size = Column(BigInteger)
     extension = Column(String)
 
+    @classmethod
+    def delete_files(cls, file_fqids):
+        delete_q = cls.__table__.delete().where(cls.fqid.in_(file_fqids))
+        config.db_session.execute(delete_q)
+
 
 class BundleFileLink(SQLAlchemyBase):
     __tablename__ = 'bundle_file_links'
@@ -66,6 +76,21 @@ class BundleFileLink(SQLAlchemyBase):
     bundle = relationship(Bundle)
     file = relationship(File)
     name = Column(String, nullable=False)
+
+    @classmethod
+    def delete_links_for_bundles(cls, bundle_fqids):
+        delete_q = cls.__table__.delete().where(cls.bundle_fqid.in_(bundle_fqids))
+        config.db_session.execute(delete_q)
+
+    @classmethod
+    def select_links_for_bundle_fqids(cls, bundle_fqids):
+        links = cls.__table__.select().where(cls.bundle_fqid.in_(bundle_fqids))
+        return config.db_session.execute(links)
+
+    @classmethod
+    def select_links_for_file_fqids(cls, file_fqids):
+        links = cls.__table__.select().where(cls.file_fqid.in_(file_fqids))
+        return config.db_session.execute(links)
 
 
 class ConnectionTypeEnum(enum.Enum):

--- a/dcpquery/etl/__init__.py
+++ b/dcpquery/etl/__init__.py
@@ -1,5 +1,6 @@
 import os, re, json, tempfile, logging
 from collections import OrderedDict
+from contextlib import contextmanager
 
 from dcplib.etl import DSSExtractor
 
@@ -245,7 +246,15 @@ def etl_one_bundle(bundle_uuid, bundle_version):
 
 
 def drop_one_bundle(bundle_uuid, bundle_version):
-    pass
+    bundle_fqid = bundle_uuid + '.' + bundle_version
+    file_fqids = [link[1] for link in BundleFileLink.select_links_for_bundle_fqids([bundle_fqid])]
+    BundleFileLink.delete_links_for_bundles([bundle_fqid])
+    files_to_keep = [link[1] for link in BundleFileLink.select_links_for_file_fqids(file_fqids)]
+    files_to_delete = list(set(file_fqids) - set(files_to_keep))
+    # TODO @madison once processes link to file versions cascade file deletions to associated processes
+    File.delete_files(files_to_delete)
+    Bundle.delete_bundles([bundle_fqid])
+    config.db_session.commit()
 
 
 def process_bundle_event(dss_event):

--- a/dcpquery/etl/__init__.py
+++ b/dcpquery/etl/__init__.py
@@ -258,6 +258,8 @@ def drop_one_bundle(bundle_uuid, bundle_version):
 
 
 def process_bundle_event(dss_event):
+    config.readonly_db = False
+    config.reset_db_session()
     if dss_event["event_type"] == "CREATE":
         etl_one_bundle(**dss_event["match"])
     elif dss_event["event_type"] in {"TOMBSTONE", "DELETE"}:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,6 +32,8 @@ vx_bundle_aggregate_md = json.loads(load_fixture('vx_bundle_document.json'))
 fast_query_mock_result = json.loads(load_fixture('fast_query_mock_result.json'))
 fast_query_expected_results = json.loads(load_fixture('fast_query_expected_results.json'))
 mock_links = json.loads(load_fixture('process_links.json'))
+mock_bundle_deletion_event = json.loads(
+    json.loads(load_fixture('mock_sqs_bundle_delete_event.json'))['Records'][0]['body'])
 vx_bundle = Bundle(fqid=vx_bundle_fqid,
                    manifest=json.loads(vx_bundle_manifest),
                    aggregate_metadata=vx_bundle_aggregate_md)

--- a/tests/unit/test_bundle_updates.py
+++ b/tests/unit/test_bundle_updates.py
@@ -6,7 +6,7 @@ from dcpquery.etl import drop_one_bundle, process_bundle_event
 from tests import mock_bundle_deletion_event
 
 
-class BundleUpdateEvewnts(unittest.TestCase):
+class BundleUpdateEvents(unittest.TestCase):
     def test_drop_one_bundle_handles_deletion(self):
         bundle_uuid = 'dfb5a10e-656f-4faa-a0c9-588afdd47e10'
         bundle_version = '2018-10-11T220440.437634Z'

--- a/tests/unit/test_bundle_updates.py
+++ b/tests/unit/test_bundle_updates.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import patch
+
+from dcpquery import config
+from dcpquery.etl import drop_one_bundle, process_bundle_event
+from tests import mock_bundle_deletion_event
+
+
+class BundleUpdateEvewnts(unittest.TestCase):
+    def test_drop_one_bundle_handles_deletion(self):
+        bundle_uuid = 'dfb5a10e-656f-4faa-a0c9-588afdd47e10'
+        bundle_version = '2018-10-11T220440.437634Z'
+        bundle_fqid = bundle_uuid + '.' + bundle_version
+
+        file_count = config.db_session.execute("SELECT COUNT(*) from files;").fetchall()[0][0]
+        self.assertEqual(config.db_session.execute(
+            f"SELECT COUNT(*) FROM bundles WHERE fqid='{bundle_fqid}'").fetchall()[0][0], 1)
+
+        self.assertEqual(config.db_session.execute(
+            f"SELECT COUNT(*) FROM bundle_file_links where bundle_fqid='{bundle_fqid}'").fetchall()[0][0], 50)
+        drop_one_bundle(bundle_uuid, bundle_version)
+        self.assertEqual(config.db_session.execute(
+            f"SELECT COUNT(*) FROM bundles WHERE fqid='{bundle_fqid}'").fetchall()[0][0], 0)
+
+        self.assertEqual(config.db_session.execute(
+            f"SELECT COUNT(*) FROM bundle_file_links where bundle_fqid='{bundle_fqid}'").fetchall()[0][0], 0)
+        config.reset_db_session()
+        post_deletion_file_count = config.db_session.execute("SELECT COUNT(*) from files;").fetchall()[0][0]
+
+        self.assertLess(post_deletion_file_count, file_count)
+
+    @patch('dcpquery.etl.drop_one_bundle')
+    def test_process_bundle_event_handles_deletions(self, mock_bundle_drop):
+        process_bundle_event(mock_bundle_deletion_event)
+        mock_bundle_drop.assert_called_once_with(
+            bundle_uuid='5541acba-066e-4b1e-9420-323513d0a899', bundle_version='2018-10-05T103504.447604Z'
+        )

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -242,16 +242,20 @@ class TestDBManager:
             $$ LANGUAGE SQL;
     """
 
-    def create_upsert_rules_in_db(cls):
+    def create_upsert_rules_in_db(self):
         config.db_session.execute(
-            cls.bundle_file_link_ignore_duplicate_rule_sql + cls.bundle_ignore_duplicate_rule_sql
+            self.bundle_file_link_ignore_duplicate_rule_sql + self.bundle_ignore_duplicate_rule_sql
         )
         config.db_session.execute(
-            cls.process_file_link_ignore_duplicate_rule_sql + cls.process_ignore_duplicate_rule_sql
+            self.process_file_link_ignore_duplicate_rule_sql + self.process_ignore_duplicate_rule_sql
         )
-        config.db_session.execute(cls.file_ignore_duplicate_rule_sql)
+        config.db_session.execute(self.file_ignore_duplicate_rule_sql)
         config.db_session.commit()
 
-    def create_recursive_functions_in_db(cls):
-        config.db_session.execute(cls.get_all_children_function_sql + cls.get_all_parents_function_sql)
+    def create_recursive_functions_in_db(self):
+        config.db_session.execute(self.get_all_children_function_sql + self.get_all_parents_function_sql)
         config.db_session.commit()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -11,364 +11,371 @@ from tests import vx_bundle, vx_bf_links, clear_views, truncate_tables, eventual
 from dcpquery import config
 
 
-class TestReadOnlyTransactions(unittest.TestCase):
-    def test_read_only_returns_column_names(self):
-        project_file = next(l.file for l in vx_bf_links if l.name == 'project_0.json')
-        config.db_session.add(project_file)
-        config.db_session.commit()
+# class TestReadOnlyTransactions(unittest.TestCase):
+#     def test_read_only_returns_column_names(self):
+#         project_file = next(l.file for l in vx_bf_links if l.name == 'project_0.json')
+#         config.db_session.add(project_file)
+#         config.db_session.commit()
+#
+#         row = next(config.db.execute("SELECT * FROM FILES;"))
+#         expected_column_names = ['fqid', 'uuid', 'version', 'dcp_schema_type_name', 'body', 'content_type', 'size',
+#                                  'extension']
+#
+#         self.assertEqual(list(dict(row).keys()), expected_column_names)
+#
+#
+# class TestPostgresLoader(unittest.TestCase):
+#     project_file = next(l.file for l in vx_bf_links if l.name == 'project_0.json')
+#     process_file = next(l.file for l in vx_bf_links if l.name == 'process_0.json')
+#
+#     def test_insert_select_file(self):
+#         # insert files
+#         config.db_session.add_all([self.project_file, self.process_file])
+#         config.db_session.commit()
+#
+#         # select files
+#         res = config.db_session.query(File).filter(File.uuid == self.project_file.uuid,
+#                                                    File.version == self.project_file.version)
+#         result = list(res)
+#         self.assertEqual(len(result), 1)
+#         self.assertEqual(result[0].uuid, self.project_file.uuid)
+#         self.assertEqual(result[0].version, self.project_file.version)
+#         expect_version = self.project_file.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
+#         self.assertEqual(result[0].fqid, f"{self.project_file.uuid}.{expect_version}")
+#         self.assertEqual(result[0].body, self.project_file.body)
+#
+#     def test_insert_select_bundle(self):
+#         # insert bundle
+#         config.db_session.add(vx_bundle)
+#         config.db_session.commit()
+#
+#         # select bundle
+#         res = config.db_session.query(Bundle).filter(Bundle.uuid == vx_bundle.uuid,
+#                                                      Bundle.version == vx_bundle.version)
+#         result = list(res)
+#         self.assertEqual(len(result), 1)
+#         self.assertEqual(result[0].uuid, vx_bundle.uuid)
+#         self.assertEqual(result[0].version, vx_bundle.version)
+#         expect_version = vx_bundle.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
+#         self.assertEqual(result[0].fqid, f"{vx_bundle.uuid}.{expect_version}")
+#         self.assertDictEqual(result[0].aggregate_metadata, vx_bundle_aggregate_md)
+#         self.assertEqual(len(result[0].files), len(vx_bundle.files))
+#         self.assertSetEqual(set(f.fqid for f in vx_bundle.files), set(f.fqid for f in result[0].files))
+#
+#     def test_insert_select_bundle_file_link(self):
+#         # insert bundle-file links
+#         config.db_session.add_all(vx_bf_links)
+#         config.db_session.commit()
+#
+#         # select bundle-file links
+#         res = config.db_session.query(BundleFileLink).filter(BundleFileLink.bundle_fqid == vx_bundle.fqid,
+#                                                              BundleFileLink.file_fqid == self.process_file.fqid)
+#         result = list(res)
+#         self.assertEqual(len(result), 1)
+#         self.assertEqual(result[0].name, "process_0.json")
+#         self.assertEqual(result[0].bundle_fqid, vx_bundle.fqid)
+#         self.assertEqual(result[0].file_fqid, self.process_file.fqid)
+#
+#         res = config.db_session.query(BundleFileLink).filter(BundleFileLink.bundle_fqid == vx_bundle.fqid)
+#         result = sorted(res, key=lambda x: x.file_fqid)
+#         self.assertEqual(len(result), 14)
+#         expect_version = vx_bundle.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
+#
+#         self.assertEqual(result[1].bundle_fqid, f"{vx_bundle.uuid}.{expect_version}")
+#         expect_version = self.process_file.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
+#         self.assertEqual(result[1].file_fqid, f"{self.process_file.uuid}.{expect_version}")
+#
+#         self.assertEqual(result[6].bundle_fqid, f"{vx_bundle.uuid}.{expect_version}")
+#
+#         expect_version = self.project_file.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
+#         self.assertEqual(result[6].file_fqid, f"{self.project_file.uuid}.{expect_version}")
+#
+#     @unittest.skip("WIP")
+#     def test_table_create_list(self):
+#         num_test_tables = 3
+#         test_table_names = [
+#             f"test_table_{secrets.token_hex(12)}" for _ in range(num_test_tables)
+#         ]
+#
+#         # def test_list(tables: Tables, num_intersecting_tables: int):
+#
+#         @eventually(5.0, 1.0)
+#         def test_list(tables, num_intersecting_tables: int):
+#             ls_result = set(tables.files.select_views())
+#             inner_result = ls_result & set(test_table_names)
+#             self.assertEqual(len(inner_result), num_intersecting_tables)
+#
+#         try:
+#             with self.db.transaction() as (cursor, tables):
+#                 # create
+#                 for table_name in test_table_names:
+#                     tables.files.create_view(table_name, schema_type=secrets.token_hex(8))
+#                 # list
+#                 test_list(tables, num_test_tables)
+#         finally:
+#             with self.db.transaction() as (cursor, _):
+#                 clear_views(cursor)
+#             self.db._connection.commit()
+#             with self.db.transaction() as (_, tables):
+#                 test_list(tables, 0)
+#
+#     def test_get_all_parents(self):
+#         load_links(mock_links['links'])
+#
+#         parent_processes = Process.list_all_parent_processes('a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+#         expected_parents = ['a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000004-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
+#         self.assertCountEqual(expected_parents, parent_processes)
+#
+#     def test_get_all_children(self):
+#         load_links(mock_links['links'])
+#
+#         child_processes = Process.list_all_child_processes('a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+#         expected_children = ['a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000001-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+#                              'a0000002-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
+#         self.assertCountEqual(expected_children, child_processes)
+#
+#
+# # Note: these tests alter global state and so may not play well with other concurrent tests/operations
+# class TestDBRules(unittest.TestCase):
+#     @classmethod
+#     def setUpClass(cls):
+#         cls.uuid = "a309af02-0888-4184-bcf2-5971dec9e8ab"
+#         cls.version = "2018-09-06T190237.485774Z"
+#         config.db_session.add(File(uuid=cls.uuid, version=cls.version))
+#         config.db_session.add(Bundle(uuid=cls.uuid, version=cls.version))
+#         config.db_session.add(Process(process_uuid=cls.uuid))
+#         config.db_session.add(ProcessFileLink(
+#             process_uuid=cls.uuid, file_uuid=cls.uuid, process_file_connection_type="INPUT_ENTITY")
+#         )
+#         config.db_session.add(
+#             BundleFileLink(bundle_fqid=cls.uuid + "." + cls.version, file_fqid=cls.uuid + "." + cls.version, name='boo')
+#         )
+#         config.db_session.commit()
+#
+#         # remove rules
+#         config.db_session.execute("DROP RULE file_table_ignore_duplicate_inserts ON files;")
+#         config.db_session.execute("DROP RULE bundle_table_ignore_duplicate_inserts ON bundles;")
+#         config.db_session.execute("DROP RULE process_table_ignore_duplicate_inserts ON processes;")
+#         config.db_session.execute(
+#             "DROP RULE process_file_join_table_ignore_duplicate_inserts ON process_file_join_table;"
+#         )
+#         config.db_session.execute("DROP RULE bundle_file_join_table_ignore_duplicate_inserts ON bundle_file_links;")
+#         config.db_session.commit()
+#
+#     @classmethod
+#     def tearDownClass(cls):
+#         config.db_session.rollback()
+#
+#         TestDBManager().create_upsert_rules_in_db()
+#
+#     def test_file_table_rule(self):
+#         # Test db throws an error without rule
+#         with self.assertRaises(sqlalchemy.exc.IntegrityError):
+#             config.db_session.add(File(uuid=self.uuid, version=self.version))
+#             config.db_session.commit()
+#         config.db_session.rollback()
+#
+#         # add rule
+#         config.db_session.execute(TestDBManager.file_ignore_duplicate_rule_sql)
+#         config.db_session.commit()
+#
+#         # try to add duplicate file, check no error thrown
+#         config.db_session.add(File(uuid=self.uuid, version=self.version))
+#         config.db_session.commit()
+#
+#     def test_bundle_table_rule(self):
+#         with self.assertRaises(sqlalchemy.exc.IntegrityError):
+#             config.db_session.add(Bundle(uuid=self.uuid, version=self.version))
+#             config.db_session.commit()
+#         config.db_session.rollback()
+#
+#         # add rule
+#         config.db_session.execute(TestDBManager.bundle_ignore_duplicate_rule_sql)
+#         config.db_session.commit()
+#
+#         # try to add duplicate file, check no error thrown
+#         config.db_session.add(Bundle(uuid=self.uuid, version=self.version))
+#         config.db_session.commit()
+#
+#     def test_process_table_rule(self):
+#         with self.assertRaises(sqlalchemy.exc.IntegrityError):
+#             config.db_session.add(Process(process_uuid=self.uuid))
+#             config.db_session.commit()
+#         config.db_session.rollback()
+#
+#         # add rule
+#         config.db_session.execute(TestDBManager.process_ignore_duplicate_rule_sql)
+#         config.db_session.commit()
+#
+#         # try to add duplicate file, check no error thrown
+#         config.db_session.add(Process(process_uuid=self.uuid))
+#         config.db_session.commit()
+#
+#     def test_process_file_link_table_rule(self):
+#         with self.assertRaises(sqlalchemy.exc.IntegrityError):
+#             config.db_session.add(ProcessFileLink(
+#                 process_uuid=self.uuid, file_uuid=self.uuid, process_file_connection_type="INPUT_ENTITY")
+#             )
+#             config.db_session.commit()
+#         config.db_session.rollback()
+#
+#         # add rule
+#         config.db_session.execute(TestDBManager.process_file_link_ignore_duplicate_rule_sql)
+#         config.db_session.commit()
+#
+#         # try to add duplicate file, check no error thrown
+#         config.db_session.add(ProcessFileLink(
+#             process_uuid=self.uuid, file_uuid=self.uuid, process_file_connection_type="INPUT_ENTITY")
+#         )
+#         config.db_session.commit()
+#
+#     def test_bundle_file_link_table_rule(self):
+#         with self.assertRaises(sqlalchemy.exc.IntegrityError):
+#             config.db_session.add(
+#                 BundleFileLink(
+#                     bundle_fqid=self.uuid + "." + self.version,
+#                     file_fqid=self.uuid + "." + self.version,
+#                     name='boo'
+#                 )
+#             )
+#             config.db_session.commit()
+#         config.db_session.rollback()
+#
+#         # add rule
+#         config.db_session.execute(TestDBManager.bundle_file_link_ignore_duplicate_rule_sql)
+#         config.db_session.commit()
+#
+#         # try to add duplicate file, check no error thrown
+#         config.db_session.add(
+#             BundleFileLink(
+#                 bundle_fqid=self.uuid + "." + self.version,
+#                 file_fqid=self.uuid + "." + self.version, name='boo'
+#             )
+#         )
+#         config.db_session.commit()
+# # class TestDatabaseUtils(unittest.TestCase):
+#     def test_db_cli(self):
+#         orig_argv = sys.argv
+#         sys.argv = ["prog", "--help"]
+#         try:
+#             import dcpquery.db.__main__
+#         except SystemExit as e:
+#             self.assertEqual(e.args[0], os.EX_OK)
+#         sys.argv = orig_argv
+#
+#     def test_init_db(self):
+#         init_db(dry_run=True)
+#         init_db()  # dry_run is True by default
+#
+#     def test_drop_db(self):
+#         drop_db(dry_run=True)
+#         drop_db()  # dry_run is True by default
+#
+#
+# class xTestDBManager:
+#     process_file_link_ignore_duplicate_rule_sql = """
+#         CREATE OR REPLACE RULE process_file_join_table_ignore_duplicate_inserts AS
+#             ON INSERT TO process_file_join_table
+#                 WHERE EXISTS (
+#                   SELECT 1
+#                 FROM process_file_join_table
+#                 WHERE process_uuid = NEW.process_uuid
+#                 AND process_file_connection_type=NEW.process_file_connection_type
+#                 AND file_uuid=NEW.file_uuid
+#             )
+#             DO INSTEAD NOTHING;
+#     """
+#     file_ignore_duplicate_rule_sql = """
+#         CREATE OR REPLACE RULE file_table_ignore_duplicate_inserts AS
+#             ON INSERT TO files
+#                 WHERE EXISTS (
+#                   SELECT 1
+#                 FROM files
+#                 WHERE fqid = NEW.fqid
+#             )
+#             DO INSTEAD NOTHING;
+#     """
+#     bundle_ignore_duplicate_rule_sql = """
+#         CREATE OR REPLACE RULE bundle_table_ignore_duplicate_inserts AS
+#             ON INSERT TO bundles
+#                 WHERE EXISTS (
+#                   SELECT 1
+#                 FROM bundles
+#                 WHERE fqid = NEW.fqid
+#             )
+#             DO INSTEAD NOTHING;
+#     """
+#     bundle_file_link_ignore_duplicate_rule_sql = """
+#         CREATE OR REPLACE RULE bundle_file_join_table_ignore_duplicate_inserts AS
+#             ON INSERT TO bundle_file_links
+#                 WHERE EXISTS (
+#                   SELECT 1
+#                 FROM bundle_file_links
+#                 WHERE bundle_fqid = NEW.bundle_fqid
+#                 AND file_fqid = NEW.file_fqid
+#             )
+#             DO INSTEAD NOTHING;
+#     """
+#     process_ignore_duplicate_rule_sql = """
+#         CREATE OR REPLACE RULE process_table_ignore_duplicate_inserts AS
+#             ON INSERT TO processes
+#                 WHERE EXISTS (
+#                   SELECT 1
+#                 FROM processes
+#                 WHERE process_uuid = NEW.process_uuid
+#             )
+#             DO INSTEAD NOTHING;
+#     """
+#
+#     get_all_children_function_sql = """
+#         CREATE or REPLACE FUNCTION get_all_children(IN parent_process_uuid UUID)
+#             RETURNS TABLE(child_process UUID) as $$
+#               WITH RECURSIVE recursive_table AS (
+#                 SELECT child_process_uuid FROM process_join_table
+#                 WHERE parent_process_uuid=$1
+#                 UNION
+#                 SELECT process_join_table.child_process_uuid FROM process_join_table
+#                 INNER JOIN recursive_table
+#                 ON process_join_table.parent_process_uuid = recursive_table.child_process_uuid)
+#             SELECT * from recursive_table;
+#             $$ LANGUAGE SQL;
+#     """
+#     get_all_parents_function_sql = """
+#         CREATE or REPLACE FUNCTION get_all_parents(IN child_process_uuid UUID)
+#             RETURNS TABLE(parent_process UUID) as $$
+#               WITH RECURSIVE recursive_table AS (
+#                 SELECT parent_process_uuid FROM process_join_table
+#                 WHERE child_process_uuid=$1
+#                 UNION
+#                 SELECT process_join_table.parent_process_uuid FROM process_join_table
+#                 INNER JOIN recursive_table
+#                 ON process_join_table.child_process_uuid = recursive_table.parent_process_uuid)
+#             SELECT * from recursive_table;
+#             $$ LANGUAGE SQL;
+#     """
+#
+#     def create_upsert_rules_in_db(cls):
+#         config.db_session.execute(
+#             cls.bundle_file_link_ignore_duplicate_rule_sql + cls.bundle_ignore_duplicate_rule_sql
+#         )
+#         config.db_session.execute(
+#             cls.process_file_link_ignore_duplicate_rule_sql + cls.process_ignore_duplicate_rule_sql
+#         )
+#         config.db_session.execute(cls.file_ignore_duplicate_rule_sql)
+#         config.db_session.commit()
+#
+#     def create_recursive_functions_in_db(cls):
+#         config.db_session.execute(cls.get_all_children_function_sql + cls.get_all_parents_function_sql)
+#         config.db_session.commit()
+#
 
-        row = next(config.db.execute("SELECT * FROM FILES;"))
-        expected_column_names = ['fqid', 'uuid', 'version', 'dcp_schema_type_name', 'body', 'content_type', 'size',
-                                 'extension']
+class TestBundles(unittest.TestCase):
+    def test_delete_bundles_deletes_list_of_bundles(self):
+        bundle_fqids = [bundle[0] for bundle in config.db_session.query("fqid FROM bundles LIMIT 3;").all()]
+        Bundle.delete_bundles(bundle_fqids)
 
-        self.assertEqual(list(dict(row).keys()), expected_column_names)
-
-
-class TestPostgresLoader(unittest.TestCase):
-    project_file = next(l.file for l in vx_bf_links if l.name == 'project_0.json')
-    process_file = next(l.file for l in vx_bf_links if l.name == 'process_0.json')
-
-    def test_insert_select_file(self):
-        # insert files
-        config.db_session.add_all([self.project_file, self.process_file])
-        config.db_session.commit()
-
-        # select files
-        res = config.db_session.query(File).filter(File.uuid == self.project_file.uuid,
-                                                   File.version == self.project_file.version)
-        result = list(res)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].uuid, self.project_file.uuid)
-        self.assertEqual(result[0].version, self.project_file.version)
-        expect_version = self.project_file.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
-        self.assertEqual(result[0].fqid, f"{self.project_file.uuid}.{expect_version}")
-        self.assertEqual(result[0].body, self.project_file.body)
-
-    def test_insert_select_bundle(self):
-        # insert bundle
-        config.db_session.add(vx_bundle)
-        config.db_session.commit()
-
-        # select bundle
-        res = config.db_session.query(Bundle).filter(Bundle.uuid == vx_bundle.uuid,
-                                                     Bundle.version == vx_bundle.version)
-        result = list(res)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].uuid, vx_bundle.uuid)
-        self.assertEqual(result[0].version, vx_bundle.version)
-        expect_version = vx_bundle.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
-        self.assertEqual(result[0].fqid, f"{vx_bundle.uuid}.{expect_version}")
-        self.assertDictEqual(result[0].aggregate_metadata, vx_bundle_aggregate_md)
-        self.assertEqual(len(result[0].files), len(vx_bundle.files))
-        self.assertSetEqual(set(f.fqid for f in vx_bundle.files), set(f.fqid for f in result[0].files))
-
-    def test_insert_select_bundle_file_link(self):
-        # insert bundle-file links
-        config.db_session.add_all(vx_bf_links)
-        config.db_session.commit()
-
-        # select bundle-file links
-        res = config.db_session.query(BundleFileLink).filter(BundleFileLink.bundle_fqid == vx_bundle.fqid,
-                                                             BundleFileLink.file_fqid == self.process_file.fqid)
-        result = list(res)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0].name, "process_0.json")
-        self.assertEqual(result[0].bundle_fqid, vx_bundle.fqid)
-        self.assertEqual(result[0].file_fqid, self.process_file.fqid)
-
-        res = config.db_session.query(BundleFileLink).filter(BundleFileLink.bundle_fqid == vx_bundle.fqid)
-        result = sorted(res, key=lambda x: x.file_fqid)
-        self.assertEqual(len(result), 14)
-        expect_version = vx_bundle.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
-
-        self.assertEqual(result[1].bundle_fqid, f"{vx_bundle.uuid}.{expect_version}")
-        expect_version = self.process_file.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
-        self.assertEqual(result[1].file_fqid, f"{self.process_file.uuid}.{expect_version}")
-
-        self.assertEqual(result[6].bundle_fqid, f"{vx_bundle.uuid}.{expect_version}")
-
-        expect_version = self.project_file.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
-        self.assertEqual(result[6].file_fqid, f"{self.project_file.uuid}.{expect_version}")
-
-    @unittest.skip("WIP")
-    def test_table_create_list(self):
-        num_test_tables = 3
-        test_table_names = [
-            f"test_table_{secrets.token_hex(12)}" for _ in range(num_test_tables)
-        ]
-
-        # def test_list(tables: Tables, num_intersecting_tables: int):
-
-        @eventually(5.0, 1.0)
-        def test_list(tables, num_intersecting_tables: int):
-            ls_result = set(tables.files.select_views())
-            inner_result = ls_result & set(test_table_names)
-            self.assertEqual(len(inner_result), num_intersecting_tables)
-
-        try:
-            with self.db.transaction() as (cursor, tables):
-                # create
-                for table_name in test_table_names:
-                    tables.files.create_view(table_name, schema_type=secrets.token_hex(8))
-                # list
-                test_list(tables, num_test_tables)
-        finally:
-            with self.db.transaction() as (cursor, _):
-                clear_views(cursor)
-            self.db._connection.commit()
-            with self.db.transaction() as (_, tables):
-                test_list(tables, 0)
-
-    def test_get_all_parents(self):
-        load_links(mock_links['links'])
-
-        parent_processes = Process.list_all_parent_processes('a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
-        expected_parents = ['a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000004-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
-        self.assertCountEqual(expected_parents, parent_processes)
-
-    def test_get_all_children(self):
-        load_links(mock_links['links'])
-
-        child_processes = Process.list_all_child_processes('a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
-        expected_children = ['a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000001-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-                             'a0000002-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
-        self.assertCountEqual(expected_children, child_processes)
-
-
-# Note: these tests alter global state and so may not play well with other concurrent tests/operations
-class TestDBRules(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.uuid = "a309af02-0888-4184-bcf2-5971dec9e8ab"
-        cls.version = "2018-09-06T190237.485774Z"
-        config.db_session.add(File(uuid=cls.uuid, version=cls.version))
-        config.db_session.add(Bundle(uuid=cls.uuid, version=cls.version))
-        config.db_session.add(Process(process_uuid=cls.uuid))
-        config.db_session.add(ProcessFileLink(
-            process_uuid=cls.uuid, file_uuid=cls.uuid, process_file_connection_type="INPUT_ENTITY")
-        )
-        config.db_session.add(
-            BundleFileLink(bundle_fqid=cls.uuid + "." + cls.version, file_fqid=cls.uuid + "." + cls.version, name='boo')
-        )
-        config.db_session.commit()
-
-        # remove rules
-        config.db_session.execute("DROP RULE file_table_ignore_duplicate_inserts ON files;")
-        config.db_session.execute("DROP RULE bundle_table_ignore_duplicate_inserts ON bundles;")
-        config.db_session.execute("DROP RULE process_table_ignore_duplicate_inserts ON processes;")
-        config.db_session.execute(
-            "DROP RULE process_file_join_table_ignore_duplicate_inserts ON process_file_join_table;"
-        )
-        config.db_session.execute("DROP RULE bundle_file_join_table_ignore_duplicate_inserts ON bundle_file_links;")
-        config.db_session.commit()
-
-    @classmethod
-    def tearDownClass(cls):
-        config.db_session.rollback()
-
-        TestDBManager().create_upsert_rules_in_db()
-
-    def test_file_table_rule(self):
-        # Test db throws an error without rule
-        with self.assertRaises(sqlalchemy.exc.IntegrityError):
-            config.db_session.add(File(uuid=self.uuid, version=self.version))
-            config.db_session.commit()
-        config.db_session.rollback()
-
-        # add rule
-        config.db_session.execute(TestDBManager.file_ignore_duplicate_rule_sql)
-        config.db_session.commit()
-
-        # try to add duplicate file, check no error thrown
-        config.db_session.add(File(uuid=self.uuid, version=self.version))
-        config.db_session.commit()
-
-    def test_bundle_table_rule(self):
-        with self.assertRaises(sqlalchemy.exc.IntegrityError):
-            config.db_session.add(Bundle(uuid=self.uuid, version=self.version))
-            config.db_session.commit()
-        config.db_session.rollback()
-
-        # add rule
-        config.db_session.execute(TestDBManager.bundle_ignore_duplicate_rule_sql)
-        config.db_session.commit()
-
-        # try to add duplicate file, check no error thrown
-        config.db_session.add(Bundle(uuid=self.uuid, version=self.version))
-        config.db_session.commit()
-
-    def test_process_table_rule(self):
-        with self.assertRaises(sqlalchemy.exc.IntegrityError):
-            config.db_session.add(Process(process_uuid=self.uuid))
-            config.db_session.commit()
-        config.db_session.rollback()
-
-        # add rule
-        config.db_session.execute(TestDBManager.process_ignore_duplicate_rule_sql)
-        config.db_session.commit()
-
-        # try to add duplicate file, check no error thrown
-        config.db_session.add(Process(process_uuid=self.uuid))
-        config.db_session.commit()
-
-    def test_process_file_link_table_rule(self):
-        with self.assertRaises(sqlalchemy.exc.IntegrityError):
-            config.db_session.add(ProcessFileLink(
-                process_uuid=self.uuid, file_uuid=self.uuid, process_file_connection_type="INPUT_ENTITY")
-            )
-            config.db_session.commit()
-        config.db_session.rollback()
-
-        # add rule
-        config.db_session.execute(TestDBManager.process_file_link_ignore_duplicate_rule_sql)
-        config.db_session.commit()
-
-        # try to add duplicate file, check no error thrown
-        config.db_session.add(ProcessFileLink(
-            process_uuid=self.uuid, file_uuid=self.uuid, process_file_connection_type="INPUT_ENTITY")
-        )
-        config.db_session.commit()
-
-    def test_bundle_file_link_table_rule(self):
-        with self.assertRaises(sqlalchemy.exc.IntegrityError):
-            config.db_session.add(
-                BundleFileLink(
-                    bundle_fqid=self.uuid + "." + self.version,
-                    file_fqid=self.uuid + "." + self.version,
-                    name='boo'
-                )
-            )
-            config.db_session.commit()
-        config.db_session.rollback()
-
-        # add rule
-        config.db_session.execute(TestDBManager.bundle_file_link_ignore_duplicate_rule_sql)
-        config.db_session.commit()
-
-        # try to add duplicate file, check no error thrown
-        config.db_session.add(
-            BundleFileLink(
-                bundle_fqid=self.uuid + "." + self.version,
-                file_fqid=self.uuid + "." + self.version, name='boo'
-            )
-        )
-        config.db_session.commit()
-
-
-class TestDatabaseUtils(unittest.TestCase):
-    def test_db_cli(self):
-        orig_argv = sys.argv
-        sys.argv = ["prog", "--help"]
-        try:
-            import dcpquery.db.__main__
-        except SystemExit as e:
-            self.assertEqual(e.args[0], os.EX_OK)
-        sys.argv = orig_argv
-
-    def test_init_db(self):
-        init_db(dry_run=True)
-        init_db()  # dry_run is True by default
-
-    def test_drop_db(self):
-        drop_db(dry_run=True)
-        drop_db()  # dry_run is True by default
-
-
-class TestDBManager:
-    process_file_link_ignore_duplicate_rule_sql = """
-        CREATE OR REPLACE RULE process_file_join_table_ignore_duplicate_inserts AS
-            ON INSERT TO process_file_join_table
-                WHERE EXISTS (
-                  SELECT 1
-                FROM process_file_join_table
-                WHERE process_uuid = NEW.process_uuid
-                AND process_file_connection_type=NEW.process_file_connection_type
-                AND file_uuid=NEW.file_uuid
-            )
-            DO INSTEAD NOTHING;
-    """
-    file_ignore_duplicate_rule_sql = """
-        CREATE OR REPLACE RULE file_table_ignore_duplicate_inserts AS
-            ON INSERT TO files
-                WHERE EXISTS (
-                  SELECT 1
-                FROM files
-                WHERE fqid = NEW.fqid
-            )
-            DO INSTEAD NOTHING;
-    """
-    bundle_ignore_duplicate_rule_sql = """
-        CREATE OR REPLACE RULE bundle_table_ignore_duplicate_inserts AS
-            ON INSERT TO bundles
-                WHERE EXISTS (
-                  SELECT 1
-                FROM bundles
-                WHERE fqid = NEW.fqid
-            )
-            DO INSTEAD NOTHING;
-    """
-    bundle_file_link_ignore_duplicate_rule_sql = """
-        CREATE OR REPLACE RULE bundle_file_join_table_ignore_duplicate_inserts AS
-            ON INSERT TO bundle_file_links
-                WHERE EXISTS (
-                  SELECT 1
-                FROM bundle_file_links
-                WHERE bundle_fqid = NEW.bundle_fqid
-                AND file_fqid = NEW.file_fqid
-            )
-            DO INSTEAD NOTHING;
-    """
-    process_ignore_duplicate_rule_sql = """
-        CREATE OR REPLACE RULE process_table_ignore_duplicate_inserts AS
-            ON INSERT TO processes
-                WHERE EXISTS (
-                  SELECT 1
-                FROM processes
-                WHERE process_uuid = NEW.process_uuid
-            )
-            DO INSTEAD NOTHING;
-    """
-
-    get_all_children_function_sql = """
-        CREATE or REPLACE FUNCTION get_all_children(IN parent_process_uuid UUID)
-            RETURNS TABLE(child_process UUID) as $$
-              WITH RECURSIVE recursive_table AS (
-                SELECT child_process_uuid FROM process_join_table
-                WHERE parent_process_uuid=$1
-                UNION
-                SELECT process_join_table.child_process_uuid FROM process_join_table
-                INNER JOIN recursive_table
-                ON process_join_table.parent_process_uuid = recursive_table.child_process_uuid)
-            SELECT * from recursive_table;
-            $$ LANGUAGE SQL;
-    """
-    get_all_parents_function_sql = """
-        CREATE or REPLACE FUNCTION get_all_parents(IN child_process_uuid UUID)
-            RETURNS TABLE(parent_process UUID) as $$
-              WITH RECURSIVE recursive_table AS (
-                SELECT parent_process_uuid FROM process_join_table
-                WHERE child_process_uuid=$1
-                UNION
-                SELECT process_join_table.parent_process_uuid FROM process_join_table
-                INNER JOIN recursive_table
-                ON process_join_table.child_process_uuid = recursive_table.parent_process_uuid)
-            SELECT * from recursive_table;
-            $$ LANGUAGE SQL;
-    """
-
-    def create_upsert_rules_in_db(cls):
-        config.db_session.execute(
-            cls.bundle_file_link_ignore_duplicate_rule_sql + cls.bundle_ignore_duplicate_rule_sql
-        )
-        config.db_session.execute(
-            cls.process_file_link_ignore_duplicate_rule_sql + cls.process_ignore_duplicate_rule_sql
-        )
-        config.db_session.execute(cls.file_ignore_duplicate_rule_sql)
-        config.db_session.commit()
-
-    def create_recursive_functions_in_db(cls):
-        config.db_session.execute(cls.get_all_children_function_sql + cls.get_all_parents_function_sql)
-        config.db_session.commit()
+        # Bundle.__table__.filter
+        Bundle.filter()
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -1,382 +1,257 @@
-import os, sys
-import sqlalchemy
-import unittest, secrets
-from uuid import uuid4
+import os
+import sys
 
-# from lib.etl.load import PostgresLoader
-from dcpquery.db import Process, File, Bundle, ProcessFileLink, BundleFileLink, drop_db, init_db
-from dcpquery.etl import load_links
-from tests import vx_bundle, vx_bf_links, clear_views, truncate_tables, eventually, mock_links, vx_bundle_aggregate_md
+import sqlalchemy
+import unittest
 
 from dcpquery import config
+from dcpquery.db import File, Bundle, Process, ProcessFileLink, drop_db, init_db, BundleFileLink
+from tests import vx_bf_links
 
 
-# class TestReadOnlyTransactions(unittest.TestCase):
-#     def test_read_only_returns_column_names(self):
-#         project_file = next(l.file for l in vx_bf_links if l.name == 'project_0.json')
-#         config.db_session.add(project_file)
-#         config.db_session.commit()
-#
-#         row = next(config.db.execute("SELECT * FROM FILES;"))
-#         expected_column_names = ['fqid', 'uuid', 'version', 'dcp_schema_type_name', 'body', 'content_type', 'size',
-#                                  'extension']
-#
-#         self.assertEqual(list(dict(row).keys()), expected_column_names)
-#
-#
-# class TestPostgresLoader(unittest.TestCase):
-#     project_file = next(l.file for l in vx_bf_links if l.name == 'project_0.json')
-#     process_file = next(l.file for l in vx_bf_links if l.name == 'process_0.json')
-#
-#     def test_insert_select_file(self):
-#         # insert files
-#         config.db_session.add_all([self.project_file, self.process_file])
-#         config.db_session.commit()
-#
-#         # select files
-#         res = config.db_session.query(File).filter(File.uuid == self.project_file.uuid,
-#                                                    File.version == self.project_file.version)
-#         result = list(res)
-#         self.assertEqual(len(result), 1)
-#         self.assertEqual(result[0].uuid, self.project_file.uuid)
-#         self.assertEqual(result[0].version, self.project_file.version)
-#         expect_version = self.project_file.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
-#         self.assertEqual(result[0].fqid, f"{self.project_file.uuid}.{expect_version}")
-#         self.assertEqual(result[0].body, self.project_file.body)
-#
-#     def test_insert_select_bundle(self):
-#         # insert bundle
-#         config.db_session.add(vx_bundle)
-#         config.db_session.commit()
-#
-#         # select bundle
-#         res = config.db_session.query(Bundle).filter(Bundle.uuid == vx_bundle.uuid,
-#                                                      Bundle.version == vx_bundle.version)
-#         result = list(res)
-#         self.assertEqual(len(result), 1)
-#         self.assertEqual(result[0].uuid, vx_bundle.uuid)
-#         self.assertEqual(result[0].version, vx_bundle.version)
-#         expect_version = vx_bundle.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
-#         self.assertEqual(result[0].fqid, f"{vx_bundle.uuid}.{expect_version}")
-#         self.assertDictEqual(result[0].aggregate_metadata, vx_bundle_aggregate_md)
-#         self.assertEqual(len(result[0].files), len(vx_bundle.files))
-#         self.assertSetEqual(set(f.fqid for f in vx_bundle.files), set(f.fqid for f in result[0].files))
-#
-#     def test_insert_select_bundle_file_link(self):
-#         # insert bundle-file links
-#         config.db_session.add_all(vx_bf_links)
-#         config.db_session.commit()
-#
-#         # select bundle-file links
-#         res = config.db_session.query(BundleFileLink).filter(BundleFileLink.bundle_fqid == vx_bundle.fqid,
-#                                                              BundleFileLink.file_fqid == self.process_file.fqid)
-#         result = list(res)
-#         self.assertEqual(len(result), 1)
-#         self.assertEqual(result[0].name, "process_0.json")
-#         self.assertEqual(result[0].bundle_fqid, vx_bundle.fqid)
-#         self.assertEqual(result[0].file_fqid, self.process_file.fqid)
-#
-#         res = config.db_session.query(BundleFileLink).filter(BundleFileLink.bundle_fqid == vx_bundle.fqid)
-#         result = sorted(res, key=lambda x: x.file_fqid)
-#         self.assertEqual(len(result), 14)
-#         expect_version = vx_bundle.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
-#
-#         self.assertEqual(result[1].bundle_fqid, f"{vx_bundle.uuid}.{expect_version}")
-#         expect_version = self.process_file.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
-#         self.assertEqual(result[1].file_fqid, f"{self.process_file.uuid}.{expect_version}")
-#
-#         self.assertEqual(result[6].bundle_fqid, f"{vx_bundle.uuid}.{expect_version}")
-#
-#         expect_version = self.project_file.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
-#         self.assertEqual(result[6].file_fqid, f"{self.project_file.uuid}.{expect_version}")
-#
-#     @unittest.skip("WIP")
-#     def test_table_create_list(self):
-#         num_test_tables = 3
-#         test_table_names = [
-#             f"test_table_{secrets.token_hex(12)}" for _ in range(num_test_tables)
-#         ]
-#
-#         # def test_list(tables: Tables, num_intersecting_tables: int):
-#
-#         @eventually(5.0, 1.0)
-#         def test_list(tables, num_intersecting_tables: int):
-#             ls_result = set(tables.files.select_views())
-#             inner_result = ls_result & set(test_table_names)
-#             self.assertEqual(len(inner_result), num_intersecting_tables)
-#
-#         try:
-#             with self.db.transaction() as (cursor, tables):
-#                 # create
-#                 for table_name in test_table_names:
-#                     tables.files.create_view(table_name, schema_type=secrets.token_hex(8))
-#                 # list
-#                 test_list(tables, num_test_tables)
-#         finally:
-#             with self.db.transaction() as (cursor, _):
-#                 clear_views(cursor)
-#             self.db._connection.commit()
-#             with self.db.transaction() as (_, tables):
-#                 test_list(tables, 0)
-#
-#     def test_get_all_parents(self):
-#         load_links(mock_links['links'])
-#
-#         parent_processes = Process.list_all_parent_processes('a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
-#         expected_parents = ['a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000004-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
-#         self.assertCountEqual(expected_parents, parent_processes)
-#
-#     def test_get_all_children(self):
-#         load_links(mock_links['links'])
-#
-#         child_processes = Process.list_all_child_processes('a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
-#         expected_children = ['a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000001-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-#                              'a0000002-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
-#         self.assertCountEqual(expected_children, child_processes)
-#
-#
-# # Note: these tests alter global state and so may not play well with other concurrent tests/operations
-# class TestDBRules(unittest.TestCase):
-#     @classmethod
-#     def setUpClass(cls):
-#         cls.uuid = "a309af02-0888-4184-bcf2-5971dec9e8ab"
-#         cls.version = "2018-09-06T190237.485774Z"
-#         config.db_session.add(File(uuid=cls.uuid, version=cls.version))
-#         config.db_session.add(Bundle(uuid=cls.uuid, version=cls.version))
-#         config.db_session.add(Process(process_uuid=cls.uuid))
-#         config.db_session.add(ProcessFileLink(
-#             process_uuid=cls.uuid, file_uuid=cls.uuid, process_file_connection_type="INPUT_ENTITY")
-#         )
-#         config.db_session.add(
-#             BundleFileLink(bundle_fqid=cls.uuid + "." + cls.version, file_fqid=cls.uuid + "." + cls.version, name='boo')
-#         )
-#         config.db_session.commit()
-#
-#         # remove rules
-#         config.db_session.execute("DROP RULE file_table_ignore_duplicate_inserts ON files;")
-#         config.db_session.execute("DROP RULE bundle_table_ignore_duplicate_inserts ON bundles;")
-#         config.db_session.execute("DROP RULE process_table_ignore_duplicate_inserts ON processes;")
-#         config.db_session.execute(
-#             "DROP RULE process_file_join_table_ignore_duplicate_inserts ON process_file_join_table;"
-#         )
-#         config.db_session.execute("DROP RULE bundle_file_join_table_ignore_duplicate_inserts ON bundle_file_links;")
-#         config.db_session.commit()
-#
-#     @classmethod
-#     def tearDownClass(cls):
-#         config.db_session.rollback()
-#
-#         TestDBManager().create_upsert_rules_in_db()
-#
-#     def test_file_table_rule(self):
-#         # Test db throws an error without rule
-#         with self.assertRaises(sqlalchemy.exc.IntegrityError):
-#             config.db_session.add(File(uuid=self.uuid, version=self.version))
-#             config.db_session.commit()
-#         config.db_session.rollback()
-#
-#         # add rule
-#         config.db_session.execute(TestDBManager.file_ignore_duplicate_rule_sql)
-#         config.db_session.commit()
-#
-#         # try to add duplicate file, check no error thrown
-#         config.db_session.add(File(uuid=self.uuid, version=self.version))
-#         config.db_session.commit()
-#
-#     def test_bundle_table_rule(self):
-#         with self.assertRaises(sqlalchemy.exc.IntegrityError):
-#             config.db_session.add(Bundle(uuid=self.uuid, version=self.version))
-#             config.db_session.commit()
-#         config.db_session.rollback()
-#
-#         # add rule
-#         config.db_session.execute(TestDBManager.bundle_ignore_duplicate_rule_sql)
-#         config.db_session.commit()
-#
-#         # try to add duplicate file, check no error thrown
-#         config.db_session.add(Bundle(uuid=self.uuid, version=self.version))
-#         config.db_session.commit()
-#
-#     def test_process_table_rule(self):
-#         with self.assertRaises(sqlalchemy.exc.IntegrityError):
-#             config.db_session.add(Process(process_uuid=self.uuid))
-#             config.db_session.commit()
-#         config.db_session.rollback()
-#
-#         # add rule
-#         config.db_session.execute(TestDBManager.process_ignore_duplicate_rule_sql)
-#         config.db_session.commit()
-#
-#         # try to add duplicate file, check no error thrown
-#         config.db_session.add(Process(process_uuid=self.uuid))
-#         config.db_session.commit()
-#
-#     def test_process_file_link_table_rule(self):
-#         with self.assertRaises(sqlalchemy.exc.IntegrityError):
-#             config.db_session.add(ProcessFileLink(
-#                 process_uuid=self.uuid, file_uuid=self.uuid, process_file_connection_type="INPUT_ENTITY")
-#             )
-#             config.db_session.commit()
-#         config.db_session.rollback()
-#
-#         # add rule
-#         config.db_session.execute(TestDBManager.process_file_link_ignore_duplicate_rule_sql)
-#         config.db_session.commit()
-#
-#         # try to add duplicate file, check no error thrown
-#         config.db_session.add(ProcessFileLink(
-#             process_uuid=self.uuid, file_uuid=self.uuid, process_file_connection_type="INPUT_ENTITY")
-#         )
-#         config.db_session.commit()
-#
-#     def test_bundle_file_link_table_rule(self):
-#         with self.assertRaises(sqlalchemy.exc.IntegrityError):
-#             config.db_session.add(
-#                 BundleFileLink(
-#                     bundle_fqid=self.uuid + "." + self.version,
-#                     file_fqid=self.uuid + "." + self.version,
-#                     name='boo'
-#                 )
-#             )
-#             config.db_session.commit()
-#         config.db_session.rollback()
-#
-#         # add rule
-#         config.db_session.execute(TestDBManager.bundle_file_link_ignore_duplicate_rule_sql)
-#         config.db_session.commit()
-#
-#         # try to add duplicate file, check no error thrown
-#         config.db_session.add(
-#             BundleFileLink(
-#                 bundle_fqid=self.uuid + "." + self.version,
-#                 file_fqid=self.uuid + "." + self.version, name='boo'
-#             )
-#         )
-#         config.db_session.commit()
-# # class TestDatabaseUtils(unittest.TestCase):
-#     def test_db_cli(self):
-#         orig_argv = sys.argv
-#         sys.argv = ["prog", "--help"]
-#         try:
-#             import dcpquery.db.__main__
-#         except SystemExit as e:
-#             self.assertEqual(e.args[0], os.EX_OK)
-#         sys.argv = orig_argv
-#
-#     def test_init_db(self):
-#         init_db(dry_run=True)
-#         init_db()  # dry_run is True by default
-#
-#     def test_drop_db(self):
-#         drop_db(dry_run=True)
-#         drop_db()  # dry_run is True by default
-#
-#
-# class xTestDBManager:
-#     process_file_link_ignore_duplicate_rule_sql = """
-#         CREATE OR REPLACE RULE process_file_join_table_ignore_duplicate_inserts AS
-#             ON INSERT TO process_file_join_table
-#                 WHERE EXISTS (
-#                   SELECT 1
-#                 FROM process_file_join_table
-#                 WHERE process_uuid = NEW.process_uuid
-#                 AND process_file_connection_type=NEW.process_file_connection_type
-#                 AND file_uuid=NEW.file_uuid
-#             )
-#             DO INSTEAD NOTHING;
-#     """
-#     file_ignore_duplicate_rule_sql = """
-#         CREATE OR REPLACE RULE file_table_ignore_duplicate_inserts AS
-#             ON INSERT TO files
-#                 WHERE EXISTS (
-#                   SELECT 1
-#                 FROM files
-#                 WHERE fqid = NEW.fqid
-#             )
-#             DO INSTEAD NOTHING;
-#     """
-#     bundle_ignore_duplicate_rule_sql = """
-#         CREATE OR REPLACE RULE bundle_table_ignore_duplicate_inserts AS
-#             ON INSERT TO bundles
-#                 WHERE EXISTS (
-#                   SELECT 1
-#                 FROM bundles
-#                 WHERE fqid = NEW.fqid
-#             )
-#             DO INSTEAD NOTHING;
-#     """
-#     bundle_file_link_ignore_duplicate_rule_sql = """
-#         CREATE OR REPLACE RULE bundle_file_join_table_ignore_duplicate_inserts AS
-#             ON INSERT TO bundle_file_links
-#                 WHERE EXISTS (
-#                   SELECT 1
-#                 FROM bundle_file_links
-#                 WHERE bundle_fqid = NEW.bundle_fqid
-#                 AND file_fqid = NEW.file_fqid
-#             )
-#             DO INSTEAD NOTHING;
-#     """
-#     process_ignore_duplicate_rule_sql = """
-#         CREATE OR REPLACE RULE process_table_ignore_duplicate_inserts AS
-#             ON INSERT TO processes
-#                 WHERE EXISTS (
-#                   SELECT 1
-#                 FROM processes
-#                 WHERE process_uuid = NEW.process_uuid
-#             )
-#             DO INSTEAD NOTHING;
-#     """
-#
-#     get_all_children_function_sql = """
-#         CREATE or REPLACE FUNCTION get_all_children(IN parent_process_uuid UUID)
-#             RETURNS TABLE(child_process UUID) as $$
-#               WITH RECURSIVE recursive_table AS (
-#                 SELECT child_process_uuid FROM process_join_table
-#                 WHERE parent_process_uuid=$1
-#                 UNION
-#                 SELECT process_join_table.child_process_uuid FROM process_join_table
-#                 INNER JOIN recursive_table
-#                 ON process_join_table.parent_process_uuid = recursive_table.child_process_uuid)
-#             SELECT * from recursive_table;
-#             $$ LANGUAGE SQL;
-#     """
-#     get_all_parents_function_sql = """
-#         CREATE or REPLACE FUNCTION get_all_parents(IN child_process_uuid UUID)
-#             RETURNS TABLE(parent_process UUID) as $$
-#               WITH RECURSIVE recursive_table AS (
-#                 SELECT parent_process_uuid FROM process_join_table
-#                 WHERE child_process_uuid=$1
-#                 UNION
-#                 SELECT process_join_table.parent_process_uuid FROM process_join_table
-#                 INNER JOIN recursive_table
-#                 ON process_join_table.child_process_uuid = recursive_table.parent_process_uuid)
-#             SELECT * from recursive_table;
-#             $$ LANGUAGE SQL;
-#     """
-#
-#     def create_upsert_rules_in_db(cls):
-#         config.db_session.execute(
-#             cls.bundle_file_link_ignore_duplicate_rule_sql + cls.bundle_ignore_duplicate_rule_sql
-#         )
-#         config.db_session.execute(
-#             cls.process_file_link_ignore_duplicate_rule_sql + cls.process_ignore_duplicate_rule_sql
-#         )
-#         config.db_session.execute(cls.file_ignore_duplicate_rule_sql)
-#         config.db_session.commit()
-#
-#     def create_recursive_functions_in_db(cls):
-#         config.db_session.execute(cls.get_all_children_function_sql + cls.get_all_parents_function_sql)
-#         config.db_session.commit()
-#
+class TestReadOnlyTransactions(unittest.TestCase):
+    def test_read_only_returns_column_names(self):
+        project_file = next(l.file for l in vx_bf_links if l.name == 'project_0.json')
+        config.db_session.add(project_file)
+        config.db_session.commit()
 
-class TestBundles(unittest.TestCase):
-    def test_delete_bundles_deletes_list_of_bundles(self):
-        bundle_fqids = [bundle[0] for bundle in config.db_session.query("fqid FROM bundles LIMIT 3;").all()]
-        Bundle.delete_bundles(bundle_fqids)
+        row = next(config.db.execute("SELECT * FROM FILES;"))
+        expected_column_names = ['fqid', 'uuid', 'version', 'dcp_schema_type_name', 'body', 'content_type', 'size',
+                                 'extension']
 
-        # Bundle.__table__.filter
-        Bundle.filter()
+        self.assertEqual(list(dict(row).keys()), expected_column_names)
 
 
-if __name__ == '__main__':
-    unittest.main()
+# Note: these tests alter global state and so may not play well with other concurrent tests/operations
+class TestDBRules(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.uuid = "a309af02-0888-4184-bcf2-5971dec9e8ab"
+        cls.version = "2018-09-06T190237.485774Z"
+        config.db_session.add(File(uuid=cls.uuid, version=cls.version))
+        config.db_session.add(Bundle(uuid=cls.uuid, version=cls.version))
+        config.db_session.add(Process(process_uuid=cls.uuid))
+        config.db_session.add(ProcessFileLink(
+            process_uuid=cls.uuid, file_uuid=cls.uuid, process_file_connection_type="INPUT_ENTITY")
+        )
+        config.db_session.add(
+            BundleFileLink(bundle_fqid=cls.uuid + "." + cls.version, file_fqid=cls.uuid + "." + cls.version, name='boo')
+        )
+        config.db_session.commit()
+
+        # remove rules
+        config.db_session.execute("DROP RULE file_table_ignore_duplicate_inserts ON files;")
+        config.db_session.execute("DROP RULE bundle_table_ignore_duplicate_inserts ON bundles;")
+        config.db_session.execute("DROP RULE process_table_ignore_duplicate_inserts ON processes;")
+        config.db_session.execute(
+            "DROP RULE process_file_join_table_ignore_duplicate_inserts ON process_file_join_table;"
+        )
+        config.db_session.execute("DROP RULE bundle_file_join_table_ignore_duplicate_inserts ON bundle_file_links;")
+        config.db_session.commit()
+
+    @classmethod
+    def tearDownClass(cls):
+        config.db_session.rollback()
+        TestDBManager().create_upsert_rules_in_db()
+
+    def test_file_table_rule(self):
+        # Test db throws an error without rule
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            config.db_session.add(File(uuid=self.uuid, version=self.version))
+            config.db_session.commit()
+        config.db_session.rollback()
+
+        # add rule
+        config.db_session.execute(TestDBManager.file_ignore_duplicate_rule_sql)
+        config.db_session.commit()
+
+        # try to add duplicate file, check no error thrown
+        config.db_session.add(File(uuid=self.uuid, version=self.version))
+        config.db_session.commit()
+
+    def test_bundle_table_rule(self):
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            config.db_session.add(Bundle(uuid=self.uuid, version=self.version))
+            config.db_session.commit()
+        config.db_session.rollback()
+
+        # add rule
+        config.db_session.execute(TestDBManager.bundle_ignore_duplicate_rule_sql)
+        config.db_session.commit()
+
+        # try to add duplicate file, check no error thrown
+        config.db_session.add(Bundle(uuid=self.uuid, version=self.version))
+        config.db_session.commit()
+
+    def test_process_table_rule(self):
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            config.db_session.add(Process(process_uuid=self.uuid))
+            config.db_session.commit()
+        config.db_session.rollback()
+
+        # add rule
+        config.db_session.execute(TestDBManager.process_ignore_duplicate_rule_sql)
+        config.db_session.commit()
+
+        # try to add duplicate file, check no error thrown
+        config.db_session.add(Process(process_uuid=self.uuid))
+        config.db_session.commit()
+
+    def test_process_file_link_table_rule(self):
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            config.db_session.add(ProcessFileLink(
+                process_uuid=self.uuid, file_uuid=self.uuid, process_file_connection_type="INPUT_ENTITY")
+            )
+            config.db_session.commit()
+        config.db_session.rollback()
+
+        # add rule
+        config.db_session.execute(TestDBManager.process_file_link_ignore_duplicate_rule_sql)
+        config.db_session.commit()
+
+        # try to add duplicate file, check no error thrown
+        config.db_session.add(ProcessFileLink(
+            process_uuid=self.uuid, file_uuid=self.uuid, process_file_connection_type="INPUT_ENTITY")
+        )
+        config.db_session.commit()
+
+    def test_bundle_file_link_table_rule(self):
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            config.db_session.add(
+                BundleFileLink(
+                    bundle_fqid=self.uuid + "." + self.version,
+                    file_fqid=self.uuid + "." + self.version,
+                    name='boo'
+                )
+            )
+            config.db_session.commit()
+        config.db_session.rollback()
+
+        # add rule
+        config.db_session.execute(TestDBManager.bundle_file_link_ignore_duplicate_rule_sql)
+        config.db_session.commit()
+
+        # try to add duplicate file, check no error thrown
+        config.db_session.add(
+            BundleFileLink(
+                bundle_fqid=self.uuid + "." + self.version,
+                file_fqid=self.uuid + "." + self.version, name='boo'
+            )
+        )
+        config.db_session.commit()
+
+
+class TestDatabaseUtils(unittest.TestCase):
+    def test_db_cli(self):
+        orig_argv = sys.argv
+        sys.argv = ["prog", "--help"]
+        try:
+            import dcpquery.db.__main__
+        except SystemExit as e:
+            self.assertEqual(e.args[0], os.EX_OK)
+        sys.argv = orig_argv
+
+    def test_init_db(self):
+        init_db(dry_run=True)
+        init_db()  # dry_run is True by default
+
+    def test_drop_db(self):
+        drop_db(dry_run=True)
+        drop_db()  # dry_run is True by default
+
+
+class TestDBManager:
+    process_file_link_ignore_duplicate_rule_sql = """
+        CREATE OR REPLACE RULE process_file_join_table_ignore_duplicate_inserts AS
+            ON INSERT TO process_file_join_table
+                WHERE EXISTS (
+                  SELECT 1
+                FROM process_file_join_table
+                WHERE process_uuid = NEW.process_uuid
+                AND process_file_connection_type=NEW.process_file_connection_type
+                AND file_uuid=NEW.file_uuid
+            )
+            DO INSTEAD NOTHING;
+    """
+    file_ignore_duplicate_rule_sql = """
+        CREATE OR REPLACE RULE file_table_ignore_duplicate_inserts AS
+            ON INSERT TO files
+                WHERE EXISTS (
+                  SELECT 1
+                FROM files
+                WHERE fqid = NEW.fqid
+            )
+            DO INSTEAD NOTHING;
+    """
+    bundle_ignore_duplicate_rule_sql = """
+        CREATE OR REPLACE RULE bundle_table_ignore_duplicate_inserts AS
+            ON INSERT TO bundles
+                WHERE EXISTS (
+                  SELECT 1
+                FROM bundles
+                WHERE fqid = NEW.fqid
+            )
+            DO INSTEAD NOTHING;
+    """
+    bundle_file_link_ignore_duplicate_rule_sql = """
+        CREATE OR REPLACE RULE bundle_file_join_table_ignore_duplicate_inserts AS
+            ON INSERT TO bundle_file_links
+                WHERE EXISTS (
+                  SELECT 1
+                FROM bundle_file_links
+                WHERE bundle_fqid = NEW.bundle_fqid
+                AND file_fqid = NEW.file_fqid
+            )
+            DO INSTEAD NOTHING;
+    """
+    process_ignore_duplicate_rule_sql = """
+        CREATE OR REPLACE RULE process_table_ignore_duplicate_inserts AS
+            ON INSERT TO processes
+                WHERE EXISTS (
+                  SELECT 1
+                FROM processes
+                WHERE process_uuid = NEW.process_uuid
+            )
+            DO INSTEAD NOTHING;
+    """
+
+    get_all_children_function_sql = """
+        CREATE or REPLACE FUNCTION get_all_children(IN parent_process_uuid UUID)
+            RETURNS TABLE(child_process UUID) as $$
+              WITH RECURSIVE recursive_table AS (
+                SELECT child_process_uuid FROM process_join_table
+                WHERE parent_process_uuid=$1
+                UNION
+                SELECT process_join_table.child_process_uuid FROM process_join_table
+                INNER JOIN recursive_table
+                ON process_join_table.parent_process_uuid = recursive_table.child_process_uuid)
+            SELECT * from recursive_table;
+            $$ LANGUAGE SQL;
+    """
+    get_all_parents_function_sql = """
+        CREATE or REPLACE FUNCTION get_all_parents(IN child_process_uuid UUID)
+            RETURNS TABLE(parent_process UUID) as $$
+              WITH RECURSIVE recursive_table AS (
+                SELECT parent_process_uuid FROM process_join_table
+                WHERE child_process_uuid=$1
+                UNION
+                SELECT process_join_table.parent_process_uuid FROM process_join_table
+                INNER JOIN recursive_table
+                ON process_join_table.child_process_uuid = recursive_table.parent_process_uuid)
+            SELECT * from recursive_table;
+            $$ LANGUAGE SQL;
+    """
+
+    def create_upsert_rules_in_db(cls):
+        config.db_session.execute(
+            cls.bundle_file_link_ignore_duplicate_rule_sql + cls.bundle_ignore_duplicate_rule_sql
+        )
+        config.db_session.execute(
+            cls.process_file_link_ignore_duplicate_rule_sql + cls.process_ignore_duplicate_rule_sql
+        )
+        config.db_session.execute(cls.file_ignore_duplicate_rule_sql)
+        config.db_session.commit()
+
+    def create_recursive_functions_in_db(cls):
+        config.db_session.execute(cls.get_all_children_function_sql + cls.get_all_parents_function_sql)
+        config.db_session.commit()

--- a/tests/unit/test_database_orm.py
+++ b/tests/unit/test_database_orm.py
@@ -139,8 +139,6 @@ class TestFiles(unittest.TestCase):
 
         # select files
         result = File.select_file(file_fqid=self.project_file.fqid)
-        # res = config.db_session.query(File).filter(File.uuid == self.project_file.uuid,
-        #                                            File.version == self.project_file.version)
 
         self.assertEqual(result.uuid, self.project_file.uuid)
         self.assertEqual(result.version, self.project_file.version)

--- a/tests/unit/test_database_orm.py
+++ b/tests/unit/test_database_orm.py
@@ -1,0 +1,166 @@
+import unittest
+
+from dcpquery.db import Bundle, BundleFileLink, Process, File
+from dcpquery.etl import load_links
+from tests import vx_bundle, vx_bf_links, vx_bundle_aggregate_md, mock_links
+
+from dcpquery import config
+
+
+class TestBundles(unittest.TestCase):
+    def test_insert_select_bundle(self):
+        # config.reset_db_session()
+        config.db_session.add(vx_bundle)
+        config.db_session.commit()
+
+        # select bundle
+        bundle = Bundle.select_bundle(vx_bundle.fqid)
+        res = config.db_session.query(Bundle).filter(Bundle.uuid == vx_bundle.uuid,
+                                                     Bundle.version == vx_bundle.version).all()
+        result = list(res)
+        self.assertEqual(len(result), 1)
+
+        self.assertEqual(result[0], bundle)
+        self.assertEqual(result[0].uuid, vx_bundle.uuid)
+        self.assertEqual(result[0].version, vx_bundle.version)
+        expect_version = vx_bundle.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
+        self.assertEqual(result[0].fqid, f"{vx_bundle.uuid}.{expect_version}")
+        self.assertDictEqual(result[0].aggregate_metadata, vx_bundle_aggregate_md)
+        self.assertEqual(len(result[0].files), len(vx_bundle.files))
+        self.assertSetEqual(set(f.fqid for f in vx_bundle.files), set(f.fqid for f in result[0].files))
+
+    def test_delete_bundles_deletes_list_of_bundles(self):
+        bundle_fqids = [bundle[0] for bundle in config.db_session.query("fqid FROM bundles LIMIT 3;").all()]
+        # Need to delete bundle_file_links with fk to bundle prior to deleting the bundle
+        BundleFileLink.delete_links_for_bundles(bundle_fqids)
+
+        Bundle.delete_bundles(bundle_fqids)
+
+        for bundle_fqid in bundle_fqids:
+            self.assertEqual(Bundle.select_bundle(bundle_fqid=bundle_fqid), None)
+
+
+class TestBundleFileLinks(unittest.TestCase):
+    project_file = next(l.file for l in vx_bf_links if l.name == 'project_0.json')
+    process_file = next(l.file for l in vx_bf_links if l.name == 'process_0.json')
+
+    def test_insert_select_bundle_file_link(self):
+        # insert bundle-file links
+        config.db_session.add_all(vx_bf_links)
+        config.db_session.commit()
+
+        # select bundle-file links
+        res = config.db_session.query(BundleFileLink).filter(BundleFileLink.bundle_fqid == vx_bundle.fqid,
+                                                             BundleFileLink.file_fqid == self.process_file.fqid)
+        result = list(res)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "process_0.json")
+        self.assertEqual(result[0].bundle_fqid, vx_bundle.fqid)
+        self.assertEqual(result[0].file_fqid, self.process_file.fqid)
+
+        res = config.db_session.query(BundleFileLink).filter(BundleFileLink.bundle_fqid == vx_bundle.fqid)
+        result = sorted(res, key=lambda x: x.file_fqid)
+        self.assertEqual(len(result), 14)
+        expect_version = vx_bundle.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
+
+        self.assertEqual(result[1].bundle_fqid, f"{vx_bundle.uuid}.{expect_version}")
+        expect_version = self.process_file.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
+        self.assertEqual(result[1].file_fqid, f"{self.process_file.uuid}.{expect_version}")
+
+        self.assertEqual(result[6].bundle_fqid, f"{vx_bundle.uuid}.{expect_version}")
+
+        expect_version = self.project_file.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
+        self.assertEqual(result[6].file_fqid, f"{self.project_file.uuid}.{expect_version}")
+
+    def test_select_links_by_file_fqids(self):
+        file_fqid = config.db_session.query("fqid FROM files LIMIT 1;").all()[0][0]
+        expected_bundle_file_links = config.db_session.execute(
+            f"SELECT * FROM bundle_file_links where file_fqid='{file_fqid}'").fetchall()
+
+        config.db_session.expire_all()
+        actual_bundle_file_links = BundleFileLink.select_links_for_file_fqids([file_fqid]).fetchall()
+        self.assertCountEqual(expected_bundle_file_links, actual_bundle_file_links)
+
+    def test_delete_links_for_bundle(self):
+        bundle_fqid = config.db_session.query("bundle_fqid FROM bundle_file_links LIMIT 1;").all()[0][0]
+        bundle_file_links = config.db_session.execute(
+            f"SELECT * FROM bundle_file_links where bundle_fqid='{bundle_fqid}'").fetchall()
+        self.assertGreater(len(bundle_file_links), 0)
+        BundleFileLink.delete_links_for_bundles([bundle_fqid])
+        bundle_file_links = config.db_session.execute(
+            f"SELECT * FROM bundle_file_links where bundle_fqid='{bundle_fqid}'").fetchall()
+
+        self.assertEqual(len(bundle_file_links), 0)
+
+    def test_delete_links_for_file(self):
+        file_fqid = config.db_session.query("file_fqid FROM bundle_file_links LIMIT 1;").all()[0][0]
+        bundle_file_links = config.db_session.execute(
+            f"SELECT * FROM bundle_file_links where file_fqid='{file_fqid}'").fetchall()
+        self.assertGreater(len(bundle_file_links), 0)
+        BundleFileLink.delete_links_for_files([file_fqid])
+        bundle_file_links = config.db_session.execute(
+            f"SELECT * FROM bundle_file_links where file_fqid='{file_fqid}'").fetchall()
+
+        self.assertEqual(len(bundle_file_links), 0)
+
+    def test_select_links_by_bundle_fqids(self):
+        bundle_fqid = config.db_session.query("fqid FROM bundles LIMIT 1;").all()[0][0]
+        expected_bundle_file_links = config.db_session.execute(
+            f"SELECT * FROM bundle_file_links where bundle_fqid='{bundle_fqid}'").fetchall()
+
+        config.db_session.expire_all()
+        actual_bundle_file_links = BundleFileLink.select_links_for_bundle_fqids([bundle_fqid]).fetchall()
+        self.assertCountEqual(expected_bundle_file_links, actual_bundle_file_links)
+
+
+class TestProcesses(unittest.TestCase):
+    def test_get_all_parents(self):
+        load_links(mock_links['links'])
+
+        parent_processes = Process.list_all_parent_processes('a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+        expected_parents = ['a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000004-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
+        self.assertCountEqual(expected_parents, parent_processes)
+
+    def test_get_all_children(self):
+        load_links(mock_links['links'])
+
+        child_processes = Process.list_all_child_processes('a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+        expected_children = ['a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000001-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+                             'a0000002-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
+        self.assertCountEqual(expected_children, child_processes)
+
+
+class TestFiles(unittest.TestCase):
+    project_file = next(l.file for l in vx_bf_links if l.name == 'project_0.json')
+    process_file = next(l.file for l in vx_bf_links if l.name == 'process_0.json')
+
+    def test_insert_select_file(self):
+        # insert files
+        config.db_session.rollback()
+        config.db_session.add_all([self.project_file, self.process_file])
+        config.db_session.commit()
+
+        # select files
+        res = config.db_session.query(File).filter(File.uuid == self.project_file.uuid,
+                                                   File.version == self.project_file.version)
+        result = list(res)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].uuid, self.project_file.uuid)
+        self.assertEqual(result[0].version, self.project_file.version)
+        expect_version = self.project_file.version.strftime("%Y-%m-%dT%H%M%S.%fZ")
+        self.assertEqual(result[0].fqid, f"{self.project_file.uuid}.{expect_version}")
+        self.assertEqual(result[0].body, self.project_file.body)
+
+    def test_delete_files(self):
+        file_fqids = [file[0] for file in config.db_session.query("fqid FROM files LIMIT 3;").all()]
+        # Need to delete bundle_file_links with fk to file prior to deleting the file
+        BundleFileLink.delete_links_for_files(file_fqids)
+
+        File.delete_files(file_fqids)
+
+        for file_fqid in file_fqids:
+            self.assertEqual(File.select_file(file_fqid=file_fqid), None)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Need
- to safely delete bundles and their associated bundle_file_links and any files that were only linked to that bundle when receiving a bundle deletion event from dss

## Approach
- delete bundle_file_links and get a list of file_fqids
- delete any files that arent associated with any other bundles
- delete the bundle

## Tests
- added unit tests
- tested directly on db

## Todo
- once we include file version/fqid in the process_file_link table also delete associated processes