### PR TITLE
Configure and use one Terraform data directory per stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ npm-debug.log
 .coverage.*
 
 # Terraform files
-/.terraform
+/.terraform*
 /terraform/variables.tf
 
 /.chalice/config.json

--- a/Makefile
+++ b/Makefile
@@ -74,15 +74,16 @@ prune:
 # init-tf prepares the repo for Terraform commands. It assembles the partial S3 backend config as a JSON file, `aws_config.json`.
 # This file is referenced by the TF_CLI_ARGS_init environment variable, which is set by running `source environment`.
 init-tf:
-	-rm -f .terraform/*.tfstate
-	jq -n ".region=env.AWS_DEFAULT_REGION | .bucket=env.TF_S3_BUCKET | .key=env.APP_NAME+env.STAGE" > .terraform/aws_config.json
+	-rm -f $(TF_DATA_DIR)/*.tfstate
+	mkdir -p $(TF_DATA_DIR)
+	jq -n ".region=env.AWS_DEFAULT_REGION | .bucket=env.TF_S3_BUCKET | .key=env.APP_NAME+env.STAGE" > $(TF_DATA_DIR)/aws_config.json
 	terraform init
 
 destroy: init-tf
 	terraform destroy
 
 clean:
-	git clean -Xdf dist .terraform .chalice docs/_build tests/terraform/.terraform
+	git clean -Xdf dist .terraform* .chalice docs/_build tests/terraform/.terraform
 
 lint:
 	flake8 *.py $(APP_NAME) tests

--- a/environment
+++ b/environment
@@ -29,9 +29,10 @@ DCPQUERY_DEBUG=1
 # This is set for build reproducibility
 PYTHONHASHSEED=0
 
-TFSTATE_FILE=.terraform/remote.tfstate
+TF_DATA_DIR=.terraform.$STAGE
+TFSTATE_FILE=${TF_DATA_DIR}/remote.tfstate
 TF_CLI_ARGS_output="--state ${TFSTATE_FILE}"
-TF_CLI_ARGS_init="--backend-config ${APP_HOME}/.terraform/aws_config.json"
+TF_CLI_ARGS_init="--backend-config ${APP_HOME}/${TF_DATA_DIR}/aws_config.json"
 
 # See https://github.com/terraform-providers/terraform-provider-aws/issues/1184
 AWS_SDK_LOAD_CONFIG=1


### PR DESCRIPTION
This eliminates dangerous situations when switching environments/stages/profiles/accounts without clearing Terraform state.