### PR TITLE
chalice config: Set API Gateway stage name to match app stage

### DIFF
--- a/.chalice/config.in.json
+++ b/.chalice/config.in.json
@@ -4,18 +4,18 @@
   "autogen_policy": false,
   "lambda_memory_size": 256,
   "lambda_timeout": 900,
+  "minimum_compression_size": 0,
   "environment_variables": {
     "XDG_CONFIG_HOME": "/tmp"
   },
+  "tags": {
+    "managedBy": "chalice",
+    "project": "dcp"
+  },
   "stages": {
-    "dev": {
-      "api_gateway_stage": "api",
-      "iam_policy_file": "policy-dev.json",
-      "environment_variables": {},
-      "tags": {
-        "managedBy": "chalice",
-        "project": "dcp"
-      }
-    }
+    "dev": {},
+    "integration": {},
+    "staging": {},
+    "prod": {}
   }
 }

--- a/.chalice/config.in.json
+++ b/.chalice/config.in.json
@@ -4,7 +4,6 @@
   "autogen_policy": false,
   "lambda_memory_size": 256,
   "lambda_timeout": 900,
-  "minimum_compression_size": 0,
   "environment_variables": {
     "XDG_CONFIG_HOME": "/tmp"
   },

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ build-chalice-config:
 	cd .chalice; jq .stages.$(STAGE).tags.env=env.STAGE config.json | sponge config.json
 	cd .chalice; jq .stages.$(STAGE).tags.service=env.APP_NAME config.json | sponge config.json
 	cd .chalice; jq .stages.$(STAGE).tags.owner=env.OWNER config.json | sponge config.json
+	cd .chalice; jq .stages.$(STAGE).api_gateway_stage=env.STAGE config.json | sponge config.json
 
 # package prepares a Lambda zipfile with the help of the Chalice packager (which also emits a SAM template).
 # We also inject any wheels found in vendor.in, and rewrite the zipfile to make the build reproducible.


### PR DESCRIPTION
This allows co-located API Gateway objects to be distinguishable in the AWS Console.