### PR TITLE
Execute API queries on engine, not session

### DIFF
--- a/dcpquery-api.yml
+++ b/dcpquery-api.yml
@@ -147,11 +147,14 @@ components:
           type: string
           description: Query to run, given as a SQL string.
         params:
-          type: object
+          oneOf:
+            - type: array
+            - type: object
           description: >
-            Parameters of the query. Supply a mapping of parameters using the _named_ parameter style. For example,
-            a query to count all files over a certain size might look like `select count(*) from files where size > :s`.
-            To find all files over 1TB in size, pass the following `params` value for this query: `{"s": 2**30}}`.
+            Parameters of the query. Supply a mapping of parameters using the _format_ or _pyformat_ parameter style.
+            For example, a query to count all files over a certain size might look like
+            `select count(*) from files where size > %(sz)s`. To find all files over 1TB in size, pass the following
+            `params` value for this query: `{"sz": 2**30}}`.
       required:
         - query
 
@@ -178,7 +181,9 @@ components:
           type: string
           description: Submitted query
         params:
-          type: object
+          oneOf:
+            - type: array
+            - type: object
           description: Parameters of the submitted query
         results:
           type: array

--- a/dcpquery/db/__init__.py
+++ b/dcpquery/db/__init__.py
@@ -165,7 +165,7 @@ def migrate_db():
 
 def run_query(query, params, rows_per_page=100):
     try:
-        cursor = config.db_session.execute(query, params=params)
+        cursor = config.db.execute(query, params)
         while True:
             rows = cursor.fetchmany(size=rows_per_page)
             for row in rows:
@@ -173,7 +173,6 @@ def run_query(query, params, rows_per_page=100):
             if not rows:
                 break
     except (sqlalchemy_exceptions.InternalError, sqlalchemy_exceptions.ProgrammingError) as e:
-        config.db_session.rollback()
         raise DCPQueryError(title=e.orig.pgerror, detail={"pgcode": e.orig.pgcode})
     except sqlalchemy_exceptions.OperationalError as e:
         if "canceling statement due to statement timeout" in str(e):

--- a/tests/integration/test_endpoints.py
+++ b/tests/integration/test_endpoints.py
@@ -31,7 +31,7 @@ class TestQueryService(unittest.TestCase, DCPAssertMixin):
         self.assertEqual(response.json['query'], query)
         self.assertGreaterEqual(response.json['results'][0]['count'], 0)
 
-        query = "SELECT count(*) FROM FILES WHERE SIZE > :s;"
+        query = "SELECT count(*) FROM FILES WHERE SIZE > :(s)s;"
         params = {"s": 0}
         response = self.assertPostResponse(f"{self.api_url}/v1/query",
                                            json_request_body=dict(query=query, params=params),

--- a/tests/unit/test_create_async_query.py
+++ b/tests/unit/test_create_async_query.py
@@ -9,7 +9,7 @@ from dcpquery.api.query_jobs import process_async_query
 
 class TestCreateAsyncQuery(unittest.TestCase):
     job_id = '26f0424a-fdce-455f-ac2e-f8f5619c6eda'
-    query = "SELECT * FROM files limit :l;"
+    query = "SELECT * FROM files limit %(l)s;"
     params = {"l": 10}
     mock_event_record = {'messageId': job_id,
                          'receiptHandle': 'AAAAA',

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -29,7 +29,7 @@ class TestEndpoints(TestChaliceApp, DCPQueryUnitTest):
         self.assertEqual(len(res.json['results']), 10)
 
     def test_query_endpoint_with_params(self):
-        query = "select * from files where size > :s limit 10"
+        query = "select * from files where size > %(s)s limit 10"
         params = {"s": 0}
         res = self.assertResponse("POST", "/v1/query", requests.codes.ok, {"query": query, "params": params})
         self.assertEqual(len(res.json['results']), 10)


### PR DESCRIPTION
The session object always opens a transaction, which is not appropriate
for read-only queries and can leak state between API requests.

Fixes #191 