### PR TITLE
Always serve compressed binary responses

### DIFF
--- a/dcpquery/api/__init__.py
+++ b/dcpquery/api/__init__.py
@@ -83,7 +83,7 @@ class ChaliceWithConnexion(chalice.Chalice):
             flask_res = self.connexion_app.app.full_dispatch_request()
         res_headers = dict(flask_res.headers)
         res_headers.pop("Content-Length", None)
-        res_body = b"".join([c for c in flask_res.response]).decode()
+        res_body = b"".join([c for c in flask_res.response])
         return chalice.Response(status_code=flask_res._status_code, headers=res_headers, body=res_body)
 
 
@@ -103,5 +103,19 @@ class ChaliceWithRequestLogging(chalice.Chalice):
         return res
 
 
-class DCPQueryServer(ChaliceWithConnexion, ChaliceWithRequestLogging):
+class ChaliceWithBinaryResponses(chalice.Chalice):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.api.binary_types.append('*/*')
+
+    def _get_view_function_response(self, view_function, function_args):
+        res = super()._get_view_function_response(view_function, function_args)
+        if isinstance(res.body, dict):
+            res.body = json.dumps(res.body)
+        if not isinstance(res.body, bytes):
+            res.body = res.body.encode()
+        return res
+
+
+class DCPQueryServer(ChaliceWithConnexion, ChaliceWithRequestLogging, ChaliceWithBinaryResponses):
     pass

--- a/dcpquery/api/__init__.py
+++ b/dcpquery/api/__init__.py
@@ -1,4 +1,4 @@
-import os, sys, re, json, collections, logging, datetime, uuid
+import os, sys, re, json, collections, logging, datetime, uuid, gzip
 from decimal import Decimal
 
 import requests, connexion, chalice
@@ -103,7 +103,7 @@ class ChaliceWithRequestLogging(chalice.Chalice):
         return res
 
 
-class ChaliceWithBinaryResponses(chalice.Chalice):
+class ChaliceWithGzipBinaryResponses(chalice.Chalice):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.api.binary_types.append('*/*')
@@ -114,8 +114,11 @@ class ChaliceWithBinaryResponses(chalice.Chalice):
             res.body = json.dumps(res.body)
         if not isinstance(res.body, bytes):
             res.body = res.body.encode()
+        if "Content-Encoding" not in res.headers:
+            res.body = gzip.compress(res.body)
+            res.headers["Content-Encoding"] = "gzip"
         return res
 
 
-class DCPQueryServer(ChaliceWithConnexion, ChaliceWithRequestLogging, ChaliceWithBinaryResponses):
+class DCPQueryServer(ChaliceWithConnexion, ChaliceWithRequestLogging, ChaliceWithGzipBinaryResponses):
     pass

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,4 +1,4 @@
-import os, sys, json, re, unittest, functools, typing, collections, pprint, time
+import os, sys, json, re, unittest, functools, typing, collections, pprint, time, base64, gzip
 
 import requests
 from chalice.cli import CLIFactory
@@ -29,6 +29,7 @@ class ChaliceTestHarness:
 
     def request(self, path, headers={}, data={}, method="GET"):
         headers.setdefault("host", "localhost")
+        headers.setdefault("accept", "*/*")
         if isinstance(data, dict):
             data = json.dumps(data)
         resp_obj = requests.Response()
@@ -42,9 +43,9 @@ class ChaliceTestHarness:
             resp_obj.status_code = response['statusCode']
             resp_obj.headers = response['headers']
             resp_obj._content = response['body']
+            if resp_obj.headers["Content-Encoding"] == "gzip":
+                resp_obj._content = gzip.decompress(resp_obj._content)
         resp_obj.encoding = "utf-8"
-        if not isinstance(resp_obj._content, bytes):
-            resp_obj._content = resp_obj._content.encode()
         resp_obj.headers['Content-Length'] = str(len(resp_obj.content))
         return resp_obj
 


### PR DESCRIPTION
This allows us to serve larger responses and also to serve binary files from Lambda.