### PR TITLE
create files/bundles view tables in migration to fix broken unit tests

### DIFF
--- a/dcpquery/alembic/versions/e2b45add6f68_rename_bundle_and_file_tables.py
+++ b/dcpquery/alembic/versions/e2b45add6f68_rename_bundle_and_file_tables.py
@@ -43,9 +43,25 @@ def upgrade():
             DO INSTEAD NOTHING;
         """
     )
+    op.execute(
+        """
+          CREATE OR REPLACE VIEW files AS
+          SELECT * FROM files_all_versions
+          WHERE (uuid, version) IN (SELECT uuid, max(version) FROM files_all_versions GROUP BY uuid)
+        """
+    )
+    op.execute(
+        """
+          CREATE OR REPLACE VIEW bundles AS
+          SELECT * FROM bundles_all_versions
+          WHERE (uuid, version) IN (SELECT uuid, max(version) FROM bundles_all_versions GROUP BY uuid)
+        """
+    )
 
 
 def downgrade():
+    op.execute("DROP VIEW IF EXISTS files CASCADE;")
+    op.execute("DROP VIEW IF EXISTS bundles CASCADE ;")
     op.rename_table('bundles_all_versions', 'bundles')
     op.rename_table('files_all_versions', 'files')
     op.execute("DROP RULE IF EXISTS file_table_ignore_duplicate_inserts ON files_all_versions;")

--- a/dcpquery/db/__init__.py
+++ b/dcpquery/db/__init__.py
@@ -193,6 +193,7 @@ def init_db(dry_run=True):
 def migrate_db():
     import alembic
     from alembic.config import Config as AlembicConfig
+    from dcpquery.etl import create_view_tables
 
     logger.info("Migrating database at %s", repr(config.db.url))
 
@@ -200,6 +201,8 @@ def migrate_db():
     with config.db.begin() as connection:
         alembic_cfg.attributes['connection'] = connection
         alembic.command.upgrade(alembic_cfg, "head")
+
+    create_view_tables()
 
 
 def run_query(query, params, rows_per_page=100):

--- a/dcpquery/db/__init__.py
+++ b/dcpquery/db/__init__.py
@@ -193,7 +193,6 @@ def init_db(dry_run=True):
 def migrate_db():
     import alembic
     from alembic.config import Config as AlembicConfig
-    from dcpquery.etl import create_view_tables
 
     logger.info("Migrating database at %s", repr(config.db.url))
 
@@ -201,8 +200,6 @@ def migrate_db():
     with config.db.begin() as connection:
         alembic_cfg.attributes['connection'] = connection
         alembic.command.upgrade(alembic_cfg, "head")
-
-    create_view_tables()
 
 
 def run_query(query, params, rows_per_page=100):


### PR DESCRIPTION
## Bug
Integration tests dependent on files table are failing after merging #232 as that view table wont be created until the etl job calls create_view_tables

## Approach
create the files/bundles view tables in the migration 