### PR TITLE
commit to db once per page

### DIFF
--- a/dcpquery/db/__main__.py
+++ b/dcpquery/db/__main__.py
@@ -8,7 +8,7 @@ from hca.dss import DSSClient
 from dcplib.etl import DSSExtractor
 
 from .. import config
-from ..etl import transform_bundle, BundleLoader, dcpquery_etl_finalizer
+from ..etl import transform_bundle, BundleLoader, dcpquery_etl_finalizer, commit_to_db
 
 from . import init_db, drop_db, migrate_db
 
@@ -95,6 +95,7 @@ elif args.command in {"load", "load-test"}:
         transformer=transform_bundle,
         loader=BundleLoader().load_bundle,
         finalizer=dcpquery_etl_finalizer,
+        page_processor=commit_to_db,
         **extractor_args
     )
 elif args.command in {"connect", "run", "describe"}:

--- a/dcpquery/etl/__init__.py
+++ b/dcpquery/etl/__init__.py
@@ -75,7 +75,6 @@ class BundleLoader:
         if schema_type and schema_type not in self.schema_types:
             schema = DCPMetadataSchemaType(name=schema_type)
             config.db_session.add(schema)
-            config.db_session.commit()
             self.schema_types.append(schema_type)
 
     def load_bundle(self, bundle, extractor=None, transformer=None):
@@ -107,7 +106,6 @@ class BundleLoader:
 
             bf_links.append(BundleFileLink(bundle=bundle_row, file=file_row, name=filename))
         config.db_session.add_all(bf_links)
-        config.db_session.commit()
 
 
 def update_process_join_table():
@@ -139,6 +137,11 @@ def update_process_join_table():
        ON CONFLICT DO NOTHING;
         """
     )
+    config.db_session.commit()
+
+
+def commit_to_db(extracted_bundles):
+    config.db_session.commit()
 
 
 def dcpquery_etl_finalizer(extractor):
@@ -172,6 +175,7 @@ def create_view_tables():
               WHERE f.dcp_schema_type_name = '{schema_type}'
             """
         )
+    config.db_session.commit()
 
 
 def load_links(links, bundle_uuid):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,7 +24,7 @@ connexion==2.3.0
 coverage==4.5.3
 crc32c==1.7
 cryptography==2.3.1
-dcplib==2.1.2
+dcplib==3.1.0
 docutils==0.14
 entrypoints==0.3
 enum-compat==0.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ commonmark==0.9.0
 connexion==2.3.0
 crc32c==1.7
 cryptography==2.3.1
-dcplib==2.1.2
+dcplib==3.1.0
 docutils==0.14
 Flask==1.0.3
 future==0.17.1


### PR DESCRIPTION
## Need
- to speed up loading of bundles to remote db

## Approach
- only commit to the db once per page of bundle (default 500 bundles)

## Tests
- tested on both remote and local db in ec2 instance.
- substantial time gains when running from laptop to remote db