### PR TITLE
Dont hardcode the bundle_fqid

### DIFF
--- a/tests/unit/test_bundle_updates.py
+++ b/tests/unit/test_bundle_updates.py
@@ -2,30 +2,32 @@ import unittest
 from unittest.mock import patch
 
 from dcpquery import config
+from dcpquery.db import Bundle
 from dcpquery.etl import drop_one_bundle, process_bundle_event
 from tests import mock_bundle_deletion_event
 
 
 class BundleUpdateEvents(unittest.TestCase):
     def test_drop_one_bundle_handles_deletion(self):
-        bundle_uuid = 'dfb5a10e-656f-4faa-a0c9-588afdd47e10'
-        bundle_version = '2018-10-11T220440.437634Z'
-        bundle_fqid = bundle_uuid + '.' + bundle_version
+        bundle_fqid = config.db_session.execute(
+            "SELECT fqid FROM bundles_all_versions LIMIT 1;").fetchall()[0][0]
 
-        file_count = config.db_session.execute("SELECT COUNT(*) from files;").fetchall()[0][0]
-        self.assertEqual(config.db_session.execute(
-            f"SELECT COUNT(*) FROM bundles WHERE fqid='{bundle_fqid}'").fetchall()[0][0], 1)
+        bundle_uuid = bundle_fqid.split('.', 1)[0]
+        bundle_version = bundle_fqid.split('.', 1)[1]
 
-        self.assertEqual(config.db_session.execute(
-            f"SELECT COUNT(*) FROM bundle_file_links where bundle_fqid='{bundle_fqid}'").fetchall()[0][0], 50)
+        file_count = config.db_session.execute("SELECT COUNT(*) from files_all_versions;").fetchall()[0][0]
+        self.assertIsNotNone(Bundle.select_bundle(bundle_fqid))
+        self.assertGreaterEqual(config.db_session.execute(
+            f"SELECT COUNT(*) FROM bundle_file_links where bundle_fqid='{bundle_fqid}'").fetchall()[0][0], 0)
+
         drop_one_bundle(bundle_uuid, bundle_version)
-        self.assertEqual(config.db_session.execute(
-            f"SELECT COUNT(*) FROM bundles WHERE fqid='{bundle_fqid}'").fetchall()[0][0], 0)
 
+        self.assertIsNone(Bundle.select_bundle(bundle_fqid))
         self.assertEqual(config.db_session.execute(
             f"SELECT COUNT(*) FROM bundle_file_links where bundle_fqid='{bundle_fqid}'").fetchall()[0][0], 0)
-        config.reset_db_session()
-        post_deletion_file_count = config.db_session.execute("SELECT COUNT(*) from files;").fetchall()[0][0]
+
+        post_deletion_file_count = config.db_session.execute(
+            "SELECT COUNT(*) from files_all_versions;").fetchall()[0][0]
 
         self.assertLess(post_deletion_file_count, file_count)
 


### PR DESCRIPTION
Retrieve a bundle from the db before deleting it to ensure tests aren't dependent on the presence of a specific bundle.