### PR TITLE
replace views with materialized views

### DIFF
--- a/dcpquery/alembic/versions/e5a3141a178d_remove_view_tables.py
+++ b/dcpquery/alembic/versions/e5a3141a178d_remove_view_tables.py
@@ -24,6 +24,16 @@ def upgrade():
 def downgrade():
     op.execute(
         """
+        DROP MATERIALIZED VIEW bundles CASCADE;
+        """
+    )
+    op.execute(
+        """
+        DROP MATERIALIZED VIEW files CASCADE;
+        """
+    )
+    op.execute(
+        """
           CREATE OR REPLACE VIEW files AS
           SELECT * FROM files_all_versions
           WHERE (uuid, version) IN (SELECT uuid, max(version) FROM files_all_versions GROUP BY uuid)

--- a/dcpquery/alembic/versions/e5a3141a178d_remove_view_tables.py
+++ b/dcpquery/alembic/versions/e5a3141a178d_remove_view_tables.py
@@ -1,0 +1,38 @@
+"""remove view tables
+
+Revision ID: e5a3141a178d
+Revises: 88bab7754636
+Create Date: 2019-08-29 15:32:12.076186
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e5a3141a178d'
+down_revision = '88bab7754636'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DROP VIEW IF EXISTS files CASCADE;")
+    op.execute("DROP VIEW IF EXISTS bundles CASCADE ;")
+
+
+def downgrade():
+    op.execute(
+        """
+          CREATE OR REPLACE VIEW files AS
+          SELECT * FROM files_all_versions
+          WHERE (uuid, version) IN (SELECT uuid, max(version) FROM files_all_versions GROUP BY uuid)
+        """
+    )
+    op.execute(
+        """
+          CREATE OR REPLACE VIEW bundles AS
+          SELECT * FROM bundles_all_versions
+          WHERE (uuid, version) IN (SELECT uuid, max(version) FROM bundles_all_versions GROUP BY uuid)
+        """
+    )

--- a/dcpquery/etl/__init__.py
+++ b/dcpquery/etl/__init__.py
@@ -145,36 +145,87 @@ def commit_to_db(extracted_bundles):
 
 
 def dcpquery_etl_finalizer(extractor):
-    create_view_tables()
+    create_materialized_view_tables()
     update_process_join_table()
 
 
-def create_view_tables():
-    config.db_session.execute(
-        """
-          CREATE OR REPLACE VIEW bundles AS
-          SELECT * FROM bundles_all_versions
-          WHERE (uuid, version) IN (SELECT uuid, max(version) FROM bundles_all_versions GROUP BY uuid)
-        """
-    )
-    config.db_session.execute(
-        """
-          CREATE OR REPLACE VIEW files AS
-          SELECT * FROM files_all_versions
-          WHERE (uuid, version) IN (SELECT uuid, max(version) FROM files_all_versions GROUP BY uuid)
-        """
-    )
+def create_bundle_materialized_view(matviews):
+    if 'bundles' not in matviews:
+        config.db_session.execute(
+            """
+              CREATE MATERIALIZED VIEW bundles AS
+              SELECT * FROM bundles_all_versions
+              WHERE (uuid, version) IN (SELECT uuid, max(version) FROM bundles_all_versions GROUP BY uuid)
+            """
+        )
+        config.db_session.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS bundles_idx ON bundles (fqid);
 
+            """
+        )
+    else:
+        config.db_session.execute(
+            """
+            REFRESH MATERIALIZED VIEW CONCURRENTLY bundles
+            """
+        )
+
+
+def create_files_materialized_view(matviews):
+    if 'files' not in matviews:
+        config.db_session.execute(
+            """
+              CREATE MATERIALIZED VIEW files AS
+              SELECT * FROM files_all_versions
+              WHERE (uuid, version) IN (SELECT uuid, max(version) FROM files_all_versions GROUP BY uuid)
+            """
+        )
+        config.db_session.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS files_idx ON files (fqid);
+
+            """
+        )
+    else:
+        config.db_session.execute(
+            """
+            REFRESH MATERIALIZED VIEW CONCURRENTLY files
+            """
+        )
+
+
+def create_dcp_schema_type_materialized_views(matviews):
     schema_types = [schema[0] for schema in
                     config.db_session.query(DCPMetadataSchemaType).with_entities(DCPMetadataSchemaType.name).all()]
     for schema_type in schema_types:
-        config.db_session.execute(
-            f"""
-              CREATE OR REPLACE VIEW {schema_type} AS
-              SELECT f.* FROM files as f
-              WHERE f.dcp_schema_type_name = '{schema_type}'
-            """
-        )
+        if schema_type not in matviews:
+            config.db_session.execute(
+                f"""
+                  CREATE MATERIALIZED VIEW {schema_type} AS
+                  SELECT f.* FROM files as f
+                  WHERE f.dcp_schema_type_name = '{schema_type}'
+                """
+            )
+            config.db_session.execute(
+                f"""
+                CREATE UNIQUE INDEX IF NOT EXISTS {schema_type+'_idx'} ON {schema_type} (fqid);
+
+                """
+            )
+        else:
+            config.db_session.execute(
+                f"""
+                REFRESH MATERIALIZED VIEW CONCURRENTLY {schema_type}
+                """
+            )
+
+
+def create_materialized_view_tables():
+    matviews = [x[0] for x in config.db_session.execute("SELECT matviewname FROM pg_catalog.pg_matviews;").fetchall()]
+    create_bundle_materialized_view(matviews)
+    create_files_materialized_view(matviews)
+    create_dcp_schema_type_materialized_views(matviews)
     config.db_session.commit()
 
 

--- a/dcpquery/etl/__init__.py
+++ b/dcpquery/etl/__init__.py
@@ -149,50 +149,20 @@ def dcpquery_etl_finalizer(extractor):
     update_process_join_table()
 
 
-def create_bundle_materialized_view(matviews):
-    if 'bundles' not in matviews:
-        config.db_session.execute(
-            """
-              CREATE MATERIALIZED VIEW bundles AS
-              SELECT * FROM bundles_all_versions
-              WHERE (uuid, version) IN (SELECT uuid, max(version) FROM bundles_all_versions GROUP BY uuid)
-            """
-        )
-        config.db_session.execute(
-            """
-            CREATE UNIQUE INDEX IF NOT EXISTS bundles_idx ON bundles (fqid);
-
-            """
-        )
-    else:
-        config.db_session.execute(
-            """
-            REFRESH MATERIALIZED VIEW CONCURRENTLY bundles
-            """
-        )
+def update_bundles_materialized_view():
+    config.db_session.execute(
+        """
+        REFRESH MATERIALIZED VIEW CONCURRENTLY bundles
+        """
+    )
 
 
-def create_files_materialized_view(matviews):
-    if 'files' not in matviews:
-        config.db_session.execute(
-            """
-              CREATE MATERIALIZED VIEW files AS
-              SELECT * FROM files_all_versions
-              WHERE (uuid, version) IN (SELECT uuid, max(version) FROM files_all_versions GROUP BY uuid)
-            """
-        )
-        config.db_session.execute(
-            """
-            CREATE UNIQUE INDEX IF NOT EXISTS files_idx ON files (fqid);
-
-            """
-        )
-    else:
-        config.db_session.execute(
-            """
-            REFRESH MATERIALIZED VIEW CONCURRENTLY files
-            """
-        )
+def update_files_materialized_view():
+    config.db_session.execute(
+        """
+        REFRESH MATERIALIZED VIEW CONCURRENTLY files
+        """
+    )
 
 
 def create_dcp_schema_type_materialized_views(matviews):
@@ -224,8 +194,8 @@ def create_dcp_schema_type_materialized_views(matviews):
 def create_materialized_view_tables():
     matviews = [x[0] for x in config.db_session.execute("SELECT matviewname FROM pg_catalog.pg_matviews;").fetchall()]
     config.reset_db_timeout_seconds(880)
-    create_bundle_materialized_view(matviews)
-    create_files_materialized_view(matviews)
+    update_bundles_materialized_view()
+    update_files_materialized_view()
     create_dcp_schema_type_materialized_views(matviews)
     config.db_session.commit()
 

--- a/dcpquery/etl/__init__.py
+++ b/dcpquery/etl/__init__.py
@@ -223,6 +223,7 @@ def create_dcp_schema_type_materialized_views(matviews):
 
 def create_materialized_view_tables():
     matviews = [x[0] for x in config.db_session.execute("SELECT matviewname FROM pg_catalog.pg_matviews;").fetchall()]
+    config.reset_db_timeout_seconds(880)
     create_bundle_materialized_view(matviews)
     create_files_materialized_view(matviews)
     create_dcp_schema_type_materialized_views(matviews)

--- a/tests/unit/test_view_tables.py
+++ b/tests/unit/test_view_tables.py
@@ -36,20 +36,19 @@ class TestViewTables(unittest.TestCase):
 
     def test_db_views_exist_for_each_schema_type(self):
 
-        views = sorted([view[0] for view in config.db_session.execute(
+        matviews = sorted([view[0] for view in config.db_session.execute(
             """
-            SELECT table_name FROM INFORMATION_SCHEMA.views
-            WHERE table_schema = ANY (current_schemas(false))
+            SELECT matviewname FROM pg_catalog.pg_matviews;
             """
         ).fetchall()])
-        views.remove('files')
-        views.remove('bundles')
+        matviews.remove('files')
+        matviews.remove('bundles')
 
         schema_types = sorted(
             [schema[0] for schema in config.db_session.query(DCPMetadataSchemaType).with_entities(
                 DCPMetadataSchemaType.name).all()])
 
-        self.assertEqual(views, schema_types)
+        self.assertEqual(matviews, schema_types)
 
     def test_biomaterial_view_table_contains_all_biomaterial_files(self):
 


### PR DESCRIPTION
## Need
- to make querying of the file/bundle tables more performant 

## approach
- replace views with materialized views with an index on the fqid
- update them concurrently

## testing
- ran full etl job in the integration environment 
- ran scale test and saw improved performance 
  - 500 requests via 10 threads take 72 seconds to complete with the materialized views
  - 500 requests via 10 threads take 513 seconds to complete with views AND 172 of the requests fail due to timeout
