### PR TITLE
Enable users to traverse experiment graph using material entities (files)

### DIFF
--- a/dcpquery/alembic/versions/ee1daffb8223_add_postgresql_function_for_traversing_.py
+++ b/dcpquery/alembic/versions/ee1daffb8223_add_postgresql_function_for_traversing_.py
@@ -1,0 +1,112 @@
+"""Add postgresql function for traversing node graph
+
+Revision ID: ee1daffb8223
+Revises: e5a3141a178d
+Create Date: 2019-10-01 17:15:25.992900
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ee1daffb8223'
+down_revision = 'e5a3141a178d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DROP FUNCTION get_all_children;")
+    op.execute("DROP FUNCTION get_all_parents;")
+    op.execute(
+        """
+         CREATE or REPLACE FUNCTION children_of_process(IN parent_process_uuid UUID)
+            RETURNS TABLE(child_process UUID) as $$
+              WITH RECURSIVE recursive_table AS (
+                SELECT child_process_uuid FROM process_join_table
+                WHERE parent_process_uuid=$1
+                UNION
+                SELECT process_join_table.child_process_uuid FROM process_join_table
+                INNER JOIN recursive_table
+                ON process_join_table.parent_process_uuid = recursive_table.child_process_uuid)
+            SELECT * from recursive_table;
+            $$ LANGUAGE SQL;
+        """
+    )
+    op.execute(
+        """
+        CREATE or REPLACE FUNCTION parents_of_process(IN child_process_uuid UUID)
+            RETURNS TABLE(parent_process UUID) as $$
+              WITH RECURSIVE recursive_table AS (
+                SELECT parent_process_uuid FROM process_join_table
+                WHERE child_process_uuid=$1
+                UNION
+                SELECT process_join_table.parent_process_uuid FROM process_join_table
+                INNER JOIN recursive_table
+                ON process_join_table.child_process_uuid = recursive_table.parent_process_uuid)
+            SELECT * from recursive_table;
+            $$ LANGUAGE SQL;
+        """
+    )
+    op.execute(
+        """
+        CREATE or REPLACE FUNCTION children_of_file(IN uuid UUID)
+        RETURNS TABLE(uuid UUID) AS $$
+        SELECT file_uuid
+          FROM process_file_join_table
+          WHERE process_uuid IN (SELECT children_of_process(process_uuid)
+                                 FROM process_file_join_table
+                                 WHERE file_uuid = $1)
+            AND file_uuid != $1;
+        $$ LANGUAGE SQL;
+        """
+    )
+    op.execute(
+        """
+        CREATE or REPLACE FUNCTION parents_of_file(IN uuid UUID)
+        RETURNS TABLE(uuid UUID) AS $$
+        SELECT file_uuid
+          FROM process_file_join_table
+          WHERE process_uuid IN (SELECT parents_of_process(process_uuid)
+                                 FROM process_file_join_table
+                                 WHERE file_uuid = $1)
+            AND file_uuid != $1;
+        $$ LANGUAGE SQL;
+        """
+    )
+
+
+def downgrade():
+    op.execute("DROP FUNCTION children_of_process;")
+    op.execute("DROP FUNCTION parents_of_process;")
+    op.execute("DROP FUNCTION children_of_file;")
+    op.execute("DROP FUNCTION parents_of_file;")
+    op.execute(
+        """
+         CREATE or REPLACE FUNCTION get_all_children(IN parent_process_uuid UUID)
+            RETURNS TABLE(child_process UUID) as $$
+              WITH RECURSIVE recursive_table AS (
+                SELECT child_process_uuid FROM process_join_table
+                WHERE parent_process_uuid=$1
+                UNION
+                SELECT process_join_table.child_process_uuid FROM process_join_table
+                INNER JOIN recursive_table
+                ON process_join_table.parent_process_uuid = recursive_table.child_process_uuid)
+            SELECT * from recursive_table;
+            $$ LANGUAGE SQL;
+        """
+    )
+    op.execute(
+        """
+        CREATE or REPLACE FUNCTION get_all_parents(IN child_process_uuid UUID)
+            RETURNS TABLE(parent_process UUID) as $$
+              WITH RECURSIVE recursive_table AS (
+                SELECT parent_process_uuid FROM process_join_table
+                WHERE child_process_uuid=$1
+                UNION
+                SELECT process_join_table.parent_process_uuid FROM process_join_table
+                INNER JOIN recursive_table
+            $$ LANGUAGE SQL;
+        """
+    )

--- a/dcpquery/db/__init__.py
+++ b/dcpquery/db/__init__.py
@@ -118,12 +118,14 @@ class Process(SQLAlchemyBase):
 
     @classmethod
     def list_all_child_processes(cls, process_uuid):
-        child_process_uuids = config.db_session.execute(f"SELECT * FROM get_all_children('{process_uuid}')").fetchall()
+        child_process_uuids = config.db_session.execute(
+            f"SELECT * FROM children_of_process('{process_uuid}')").fetchall()
         return [str(child_process[0]) for child_process in child_process_uuids]
 
     @classmethod
     def list_all_parent_processes(cls, process_uuid):
-        parent_process_uuids = config.db_session.execute(f"SELECT * FROM get_all_parents('{process_uuid}')").fetchall()
+        parent_process_uuids = config.db_session.execute(
+            f"SELECT * FROM parents_of_process('{process_uuid}')").fetchall()
         return [str(parent_process[0]) for parent_process in parent_process_uuids]
 
     @classmethod

--- a/dcpquery/db/__init__.py
+++ b/dcpquery/db/__init__.py
@@ -117,25 +117,25 @@ class Process(SQLAlchemyBase):
     process_uuid = Column(UUID, primary_key=True)
 
     @classmethod
-    def list_all_child_processes(cls, process_uuid):
+    def process_subtree(cls, process_uuid):
         child_process_uuids = config.db_session.execute(
-            f"SELECT * FROM children_of_process('{process_uuid}')").fetchall()
+            f"SELECT * FROM process_subtree('{process_uuid}')").fetchall()
         return [str(child_process[0]) for child_process in child_process_uuids]
 
     @classmethod
-    def list_all_parent_processes(cls, process_uuid):
+    def process_ancestors(cls, process_uuid):
         parent_process_uuids = config.db_session.execute(
-            f"SELECT * FROM parents_of_process('{process_uuid}')").fetchall()
+            f"SELECT * FROM process_ancestors('{process_uuid}')").fetchall()
         return [str(parent_process[0]) for parent_process in parent_process_uuids]
 
     @classmethod
-    def list_all_child_files(cls, process_uuid):
-        child_process_uuids = config.db_session.execute(f"SELECT * FROM children_of_file('{process_uuid}')").fetchall()
+    def file_subtree(cls, process_uuid):
+        child_process_uuids = config.db_session.execute(f"SELECT * FROM file_subtree('{process_uuid}')").fetchall()
         return [str(child_process[0]) for child_process in child_process_uuids]
 
     @classmethod
-    def list_all_parent_files(cls, process_uuid):
-        parent_process_uuids = config.db_session.execute(f"SELECT * FROM parents_of_file('{process_uuid}')").fetchall()
+    def file_ancestors(cls, process_uuid):
+        parent_process_uuids = config.db_session.execute(f"SELECT * FROM file_ancestors('{process_uuid}')").fetchall()
         return [str(parent_process[0]) for parent_process in parent_process_uuids]
 
     @classmethod

--- a/dcpquery/db/__init__.py
+++ b/dcpquery/db/__init__.py
@@ -129,6 +129,16 @@ class Process(SQLAlchemyBase):
         return [str(parent_process[0]) for parent_process in parent_process_uuids]
 
     @classmethod
+    def list_all_child_files(cls, process_uuid):
+        child_process_uuids = config.db_session.execute(f"SELECT * FROM children_of_file('{process_uuid}')").fetchall()
+        return [str(child_process[0]) for child_process in child_process_uuids]
+
+    @classmethod
+    def list_all_parent_files(cls, process_uuid):
+        parent_process_uuids = config.db_session.execute(f"SELECT * FROM parents_of_file('{process_uuid}')").fetchall()
+        return [str(parent_process[0]) for parent_process in parent_process_uuids]
+
+    @classmethod
     def list_direct_child_processes(cls, process_uuid):
         return config.db_session.query(ProcessProcessLink).with_entities(ProcessProcessLink.child_process_uuid).filter(
             ProcessProcessLink.parent_process_uuid == process_uuid).all()

--- a/docs/index.md
+++ b/docs/index.md
@@ -139,22 +139,22 @@ Experiments are represented in HCA's metadata as a [directed acyclic graph](http
 
 ### Traversing the graph of material entities
 
-Using the `children_of_file` and `parents_of_file` postgres methods, you can find the child nodes and parent nodes of a given material entity in the experimental DAG respectively.
+Using the `file_subtree` and `file_ancestors` postgres methods, you can find the child nodes and parent nodes of a given material entity in the experimental DAG respectively.
 
 Let's say you have a FASTQ file and you are curious about the donor organism from which it was derived. If `6eeadcee-dd1a-4153-97db-db5778e830d7` is the UUID of a donor file, you can run:
 
 ```sql
-SELECT parents_of_file('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865');
+SELECT file_ancestors('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865');
 ```
 
-The results are the uuids of files represent parent material entities in the DAG for this sequence file. In other words, `parents_of_file` returns all of the inputs that went into making the file with the given UUID.
+The results are the uuids of files represent parent material entities in the DAG for this sequence file. In other words, `file_ancestors` returns all of the inputs that went into making the file with the given UUID.
 
 If we want to get the donor organism from which this file was derived from, we simply join with the files table and filter:
 
 ```sql
 SELECT * FROM files
 WHERE
-  uuid IN (SELECT parents_of_file('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865')) AND
+  uuid IN (SELECT file_ancestors('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865')) AND
   dcp_schema_type_name = 'donor_organism';
 ```
 
@@ -163,6 +163,6 @@ Conversely, you could use the UUID of the donor organism to find the sequencing 
 ```sql
 SELECT * FROM files
 WHERE
-  uuid IN (SELECT children_of_file('2107cab5-4f14-4008-bc82-4df8637c05a9')) AND
+  uuid IN (SELECT file_subtree('2107cab5-4f14-4008-bc82-4df8637c05a9')) AND
   dcp_schema_type_name = 'sequence_file';
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,41 +135,34 @@ WHERE p.body @> '{"contributors": [{"contact_name": "Aviv,,Regev"}]}'
 ```
 
 ## Querying the experimental graph
-If you have a FASTQ file and you are curious about its inputs, you can use a custom SQL function `get_all_parents` to get all of the processes that led to its creation. For example:
+Experiments are represented in HCA's metadata as a [directed acyclic graph](https://en.wikipedia.org/wiki/Directed_acyclic_graph) (DAG). Material entities--either `Project`, `File`, `Biomaterial`--are linked by immaterial entities--`Process` edges that implement a `Protocol`. For more see [this documentation](https://github.com/HumanCellAtlas/metadata-schema/blob/master/docs/structure.md#structure-overview).
 
-If your sequence file has a uuid of `8c823b32-42dc-4163-aa96-168dce981ee5` you can run: 
-```postgresql
-SELECT * FROM process_file_join_table 
-WHERE file_uuid = '8c823b32-42dc-4163-aa96-168dce981ee5';
+### Traversing the graph of material entities
+
+Using the `children_of_file` and `parents_of_file` postgres methods, you can find the child nodes and parent nodes of a given material entity in the experimental DAG respectively.
+
+Let's say you have a FASTQ file and you are curious about the donor organism from which it was derived. If `6eeadcee-dd1a-4153-97db-db5778e830d7` is the UUID of a donor file, you can run:
+
+```sql
+SELECT parents_of_file('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865');
 ```
-This should return a list of all the processes the file is associated with. Find a row that says `OUTPUT_ENTITY` and copy the `process_uuid`.
 
-Then run the following to get a list of all of its parent processes:
-```postgresql
-SELECT * FROM  get_all_parents('4028ba54-e09f-4c16-9b4e-4f0781e80c46')
+The results are the uuids of files represent parent material entities in the DAG for this sequence file. In other words, `parents_of_file` returns all of the inputs that went into making the file with the given UUID.
+
+If we want to get the donor organism from which this file was derived from, we simply join with the files table and filter:
+
+```sql
+SELECT * FROM files
+WHERE
+  uuid IN (SELECT parents_of_file('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865')) AND
+  dcp_schema_type_name = 'donor_organism';
 ```
-Things to note about the query above:
-- Direct parents are processes whose output becomes the input for the current process
-- `get_all_parents` grabs the processes whose output was the input for the current process and then gets the processes whose output was the input for the parent process and then goes all the way up to the initial file (typically a `donor_organism` file)
-- You can also use the `get_all_children` function to go the opposite way
-- This allows us to represent graphical data in a relational database
 
-`donor_organism` files are typically at the top of the graph. If you have a `file_uuid` for a `donor_organism` and you'd like to get all of the `sequence_files` that came from that donor, you can run the following substituting in the `file_uuid` of your `donor_organism`.
-```postgresql
-SELECT *
-FROM (SELECT file_uuid
-      FROM process_file_join_table
-      WHERE process_uuid IN (SELECT get_all_children(process_uuid)
-                             FROM process_file_join_table
-                             WHERE file_uuid = '79a7c087-886b-47a7-8044-76a227d963ba')) AS temp_table
-       JOIN files ON temp_table.file_uuid = files.uuid
-WHERE files.dcp_schema_type_name = 'sequence_file';
+Conversely, you could use the UUID of the donor organism to find the sequencing files derived from it:
+
+```sql
+SELECT * FROM files
+WHERE
+  uuid IN (SELECT children_of_file('2107cab5-4f14-4008-bc82-4df8637c05a9')) AND
+  dcp_schema_type_name = 'sequence_file';
 ```
-Further notes on the above query:
-
-- To get all file types, leave off the final `WHERE` clause
-- To retrieve files higher in the graph, replace `get_all_children` with `get_all_parents` 
-
-If you are trying to get all of the files in a graph, it is necessary to specifically retrieve:
-- Any input files and protocol files for a process when running `get_all_children` 
-- Any output files and protocol files for a process when running `get_all_parents`

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -223,33 +223,6 @@ class TestDBManager:
             DO INSTEAD NOTHING;
     """
 
-    get_all_children_function_sql = """
-        CREATE or REPLACE FUNCTION get_all_children(IN parent_process_uuid UUID)
-            RETURNS TABLE(child_process UUID) as $$
-              WITH RECURSIVE recursive_table AS (
-                SELECT child_process_uuid FROM process_join_table
-                WHERE parent_process_uuid=$1
-                UNION
-                SELECT process_join_table.child_process_uuid FROM process_join_table
-                INNER JOIN recursive_table
-                ON process_join_table.parent_process_uuid = recursive_table.child_process_uuid)
-            SELECT * from recursive_table;
-            $$ LANGUAGE SQL;
-    """
-    get_all_parents_function_sql = """
-        CREATE or REPLACE FUNCTION get_all_parents(IN child_process_uuid UUID)
-            RETURNS TABLE(parent_process UUID) as $$
-              WITH RECURSIVE recursive_table AS (
-                SELECT parent_process_uuid FROM process_join_table
-                WHERE child_process_uuid=$1
-                UNION
-                SELECT process_join_table.parent_process_uuid FROM process_join_table
-                INNER JOIN recursive_table
-                ON process_join_table.child_process_uuid = recursive_table.parent_process_uuid)
-            SELECT * from recursive_table;
-            $$ LANGUAGE SQL;
-    """
-
     def create_upsert_rules_in_db(self):
         config.db_session.execute(
             self.bundle_file_link_ignore_duplicate_rule_sql + self.bundle_ignore_duplicate_rule_sql
@@ -258,10 +231,6 @@ class TestDBManager:
             self.process_file_link_ignore_duplicate_rule_sql + self.process_ignore_duplicate_rule_sql
         )
         config.db_session.execute(self.file_ignore_duplicate_rule_sql)
-        config.db_session.commit()
-
-    def create_recursive_functions_in_db(self):
-        config.db_session.execute(self.get_all_children_function_sql + self.get_all_parents_function_sql)
         config.db_session.commit()
 
 

--- a/tests/unit/test_database_orm.py
+++ b/tests/unit/test_database_orm.py
@@ -120,20 +120,20 @@ class TestProcesses(unittest.TestCase):
         update_process_join_table()
 
     def test_get_all_parent_processes(self):
-        parent_processes = Process.list_all_parent_processes('a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+        parent_processes = Process.process_ancestors('a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
         expected_parents = ['a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000004-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
         self.assertCountEqual(expected_parents, parent_processes)
         self.assertSetEqual(set(expected_parents), set(parent_processes))
 
     def test_get_all_child_processes(self):
-        child_processes = Process.list_all_child_processes('a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+        child_processes = Process.process_subtree('a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
         expected_children = ['a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000001-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
                              'a0000002-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
         self.assertCountEqual(expected_children, child_processes)
         self.assertSetEqual(set(expected_children), set(child_processes))
 
-    def test_list_all_parent_files(self):
-        parent_files = Process.list_all_parent_files('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865')
+    def test_file_ancestors(self):
+        parent_files = Process.file_ancestors('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865')
         expected_files = [
             "2107cab5-4f14-4008-bc82-4df8637c05a9",
             "77af67ca-e99a-45ef-9c68-40daa76e664e",
@@ -145,7 +145,7 @@ class TestProcesses(unittest.TestCase):
         self.assertSetEqual(set(expected_files), set(parent_files))
 
     def test_get_all_child_files(self):
-        child_files = Process.list_all_child_files('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865')
+        child_files = Process.file_subtree('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865')
         expected_files = [
             "5c0e51a9-8262-42e1-bfc1-ea883f7f0d17",
             "6eeadcee-dd1a-4153-97db-db5778e830d7",

--- a/tests/unit/test_database_orm.py
+++ b/tests/unit/test_database_orm.py
@@ -123,12 +123,14 @@ class TestProcesses(unittest.TestCase):
         parent_processes = Process.list_all_parent_processes('a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
         expected_parents = ['a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000004-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
         self.assertCountEqual(expected_parents, parent_processes)
+        self.assertSetEqual(set(expected_parents), set(parent_processes))
 
     def test_get_all_children(self):
         child_processes = Process.list_all_child_processes('a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
         expected_children = ['a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000001-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
                              'a0000002-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
         self.assertCountEqual(expected_children, child_processes)
+        self.assertSetEqual(set(expected_children), set(child_processes))
 
 
 class TestFiles(unittest.TestCase):

--- a/tests/unit/test_database_orm.py
+++ b/tests/unit/test_database_orm.py
@@ -119,18 +119,42 @@ class TestProcesses(unittest.TestCase):
         config.db_session.commit()
         update_process_join_table()
 
-    def test_get_all_parents(self):
+    def test_get_all_parent_processes(self):
         parent_processes = Process.list_all_parent_processes('a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
         expected_parents = ['a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000004-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
         self.assertCountEqual(expected_parents, parent_processes)
         self.assertSetEqual(set(expected_parents), set(parent_processes))
 
-    def test_get_all_children(self):
+    def test_get_all_child_processes(self):
         child_processes = Process.list_all_child_processes('a0000003-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
         expected_children = ['a0000000-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'a0000001-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
                              'a0000002-aaaa-aaaa-aaaa-aaaaaaaaaaaa']
         self.assertCountEqual(expected_children, child_processes)
         self.assertSetEqual(set(expected_children), set(child_processes))
+
+    def test_list_all_parent_files(self):
+        parent_files = Process.list_all_parent_files('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865')
+        expected_files = [
+            "2107cab5-4f14-4008-bc82-4df8637c05a9",
+            "77af67ca-e99a-45ef-9c68-40daa76e664e",
+            "77af67ca-e99a-45ef-9c68-40daa76e664e",
+            "8b6895ba-eda2-4bf9-9d22-c9ab3fe3ae4d",
+            "d153ebcf-828a-41b7-ace8-57376349636a"
+        ]
+        self.assertCountEqual(expected_files, parent_files)
+        self.assertSetEqual(set(expected_files), set(parent_files))
+
+    def test_get_all_child_files(self):
+        child_files = Process.list_all_child_files('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865')
+        expected_files = [
+            "5c0e51a9-8262-42e1-bfc1-ea883f7f0d17",
+            "6eeadcee-dd1a-4153-97db-db5778e830d7",
+            "bccacace-69e9-4585-a7af-30287ef9545b",
+            "f6b720da-7695-4900-9e23-0c8516c2a3b2",
+            "f94db122-3f6b-47b0-8559-d635e1c6238e"
+        ]
+        self.assertCountEqual(expected_files, child_files)
+        self.assertCountEqual(set(expected_files), set(child_files))
 
 
 class TestFiles(unittest.TestCase):


### PR DESCRIPTION
## Need

User story:
* As a user of the query service (and HCA metadata), I want to ask questions in terms of material entities in an experiment, so that I can understand outputs of an experiment given its inputs.
* As a user of the query service (and HCA metadata), I want to ask questions in terms of material entities in an experiment, so that I can understand inputs of an experiment given its outputs.

The general insight here is that data consumers will generally want to primarily ask questions like:
* What sequencing files were derived from this donor?
* What donor generated this sequencing file?

... in addition to asking questions about the process graph.

## Approach

Create a convenience method that makes it easy for users to write queries based on 'material entities' on the experimental graph.

```sql
/* Given a donor's file UUID we can find the resulting sequencing files */
SELECT * FROM files
WHERE
  uuid IN (SELECT file_subtree('b7ae6dcb-b8fd-48d0-a7c7-252f8089c865')) AND
  dcp_schema_type_name = 'sequence_file';
```

### Graph term fixes

In the terminology of a [rooted tree](https://en.wikipedia.org/wiki/Tree_(graph_theory)#Rooted_tree) the parent nodes of a node N are those that have directed edges into N. The children of a node N are those that receive directed edges from N. The terms used in the function name `get_all_children` then are unclear since what the function really returns is the nodes of the graph in its subtree. Similarly, `get_all_parents` is misleading since what the function really returns is all nodes that are on a path between a node N and the root node in the DAG. This PR renames the methods to better reflect what they really return:

* `get_all_children` -> `process_subtree`
* `get_all_parents` -> `process_ancestors`