### PR TITLE
etl refactor

### DIFF
--- a/dcpquery/db/__init__.py
+++ b/dcpquery/db/__init__.py
@@ -1,7 +1,7 @@
 """
 This module provides a SQLAlchemy-based database schema for the DCP Query Service.
 """
-import os, enum, logging, typing
+import enum, logging, typing
 
 from sqlalchemy import (Column, String, DateTime, Integer, ForeignKey, Enum, exc as sqlalchemy_exceptions,
                         UniqueConstraint, BigInteger)
@@ -212,3 +212,7 @@ def run_query(query, params, rows_per_page=100):
             raise QueryTimeoutError(title=e.orig.pgerror, detail={"pgcode": e.orig.pgcode})
         else:
             raise
+
+
+def commit_to_db(arg):
+    config.db_session.commit()

--- a/dcpquery/db/__main__.py
+++ b/dcpquery/db/__main__.py
@@ -8,7 +8,9 @@ from hca.dss import DSSClient
 from dcplib.etl import DSSExtractor
 
 from .. import config
-from ..etl import transform_bundle, BundleLoader, dcpquery_etl_finalizer, commit_to_db
+from ..etl import dcpquery_etl_finalizer
+from dcpquery.db import commit_to_db
+from dcpquery.etl import transform_bundle, BundleLoader
 
 from . import init_db, drop_db, migrate_db
 

--- a/dcpquery/db/materialized_views.py
+++ b/dcpquery/db/materialized_views.py
@@ -1,0 +1,53 @@
+from dcpquery import config
+from dcpquery.db import DCPMetadataSchemaType
+
+
+def update_bundles_materialized_view():
+    config.db_session.execute(
+        """
+        REFRESH MATERIALIZED VIEW CONCURRENTLY bundles
+        """
+    )
+
+
+def update_files_materialized_view():
+    config.db_session.execute(
+        """
+        REFRESH MATERIALIZED VIEW CONCURRENTLY files
+        """
+    )
+
+
+def create_dcp_schema_type_materialized_views(matviews):
+    schema_types = [schema[0] for schema in
+                    config.db_session.query(DCPMetadataSchemaType).with_entities(DCPMetadataSchemaType.name).all()]
+    for schema_type in schema_types:
+        if schema_type not in matviews:
+            config.db_session.execute(
+                f"""
+                  CREATE MATERIALIZED VIEW {schema_type} AS
+                  SELECT f.* FROM files as f
+                  WHERE f.dcp_schema_type_name = '{schema_type}'
+                """
+            )
+            config.db_session.execute(
+                f"""
+                CREATE UNIQUE INDEX IF NOT EXISTS {schema_type+'_idx'} ON {schema_type} (fqid);
+
+                """
+            )
+        else:
+            config.db_session.execute(
+                f"""
+                REFRESH MATERIALIZED VIEW CONCURRENTLY {schema_type}
+                """
+            )
+
+
+def create_materialized_view_tables():
+    matviews = [x[0] for x in config.db_session.execute("SELECT matviewname FROM pg_catalog.pg_matviews;").fetchall()]
+    config.reset_db_timeout_seconds(880)
+    update_bundles_materialized_view()
+    update_files_materialized_view()
+    create_dcp_schema_type_materialized_views(matviews)
+    config.db_session.commit()

--- a/dcpquery/etl/__init__.py
+++ b/dcpquery/etl/__init__.py
@@ -1,111 +1,14 @@
-import os, re, json, tempfile, logging
-from collections import OrderedDict
-from contextlib import contextmanager
+import os, tempfile, logging
 
 from dcplib.etl import DSSExtractor
 
+from dcpquery.etl.load import BundleLoader
+from dcpquery.etl.transform import transform_bundle
+
 from .. import config
-from ..db import Bundle, File, BundleFileLink, ProcessFileLink, Process, ProcessProcessLink, DCPMetadataSchemaType
+from ..db import Bundle, File, BundleFileLink, DCPMetadataSchemaType
 
 logger = logging.getLogger(__name__)
-
-
-def transform_bundle(bundle_uuid, bundle_version, bundle_path, bundle_manifest_path, extractor=None):
-    """
-    This function is used with the ETL interface in dcplib.etl.DSSExtractor.extract.
-    Given a bundle ID and directory containing its medatata JSON files, it produces an intermediate representation
-    of the bundle and its files ready to be inserted into the database by BundleLoader.
-    """
-    result = dict(uuid=bundle_uuid,
-                  version=bundle_version,
-                  manifest=json.load(open(bundle_manifest_path)),
-                  aggregate_metadata={},
-                  files=OrderedDict())
-    # Load and process all the metadata files; construct the "aggregate_metadata" doc:
-    # - Singleton metadata files get inserted under their name minus the extension (project.json => {"project": {...}})
-    # - Numbered metadata files are put in an array (assay_0.json, assay_1.json => {"assay": [{...0...}, {...1...}]})
-    bundle_fetched_files = sorted(os.listdir(bundle_path)) if os.path.exists(bundle_path) else []
-    for f in bundle_fetched_files:
-        if re.match(r"(.+)_(\d+).json", f):
-            metadata_key, index = re.match(r"(.+)_(\d+).json", f).groups()
-        elif re.match(r"(.+).json", f):
-            metadata_key, index = re.match(r"(.+).json", f).group(1), None
-        else:
-            metadata_key, index = f, None
-        with open(os.path.join(bundle_path, f)) as fh:
-            file_doc = json.load(fh)
-            if index is None:
-                result["aggregate_metadata"][metadata_key] = file_doc
-            else:
-                result["aggregate_metadata"].setdefault(metadata_key, [])
-                result["aggregate_metadata"][metadata_key].append(file_doc)
-        for fm in result["manifest"]["files"]:
-            if f == fm["name"] and "schema_type" in file_doc:
-                result["files"][fm["name"]] = dict(fm,
-                                                   body=file_doc,
-                                                   schema_type=file_doc['schema_type'])
-    # For all other (non-metadata) files from the bundle manifest, insert them with a default body
-    # indicating an empty schema type.
-    for fm in result["manifest"]["files"]:
-        if fm["name"] not in result["files"]:
-            result["files"][fm["name"]] = dict(fm,
-                                               body=None,
-                                               schema_type=None)
-
-    # Flatten the file list while preserving order.
-    result["files"] = list(result["files"].values())
-    return result
-
-
-def get_file_extension(filename):
-    try:
-        regex_search_result = re.search('^(?:(?:.){1,}?)((?:[.][a-z]{1,10}){1,2})$', filename)
-        file_extension = regex_search_result.group(1)
-    except AttributeError:
-        file_extension = None
-    return file_extension
-
-
-class BundleLoader:
-    def __init__(self):
-        schema_types = config.db_session.query(DCPMetadataSchemaType).with_entities(DCPMetadataSchemaType.name).all()
-        self.schema_types = [schema[0] for schema in schema_types]
-
-    def register_dcp_metadata_schema_type(self, schema_type):
-        if schema_type and schema_type not in self.schema_types:
-            schema = DCPMetadataSchemaType(name=schema_type)
-            config.db_session.add(schema)
-            self.schema_types.append(schema_type)
-
-    def load_bundle(self, bundle, extractor=None, transformer=None):
-        bf_links = []
-        bundle_row = Bundle(uuid=bundle["uuid"],
-                            version=bundle["version"],
-                            manifest=bundle["manifest"],
-                            aggregate_metadata=bundle["aggregate_metadata"])
-        for file_data in bundle["files"]:
-            filename = file_data.pop("name")
-            file_extension = get_file_extension(filename)
-            schema_type = None
-            if file_data['body']:
-                schema_type = file_data['body'].get('describedBy', '').split('/')[-1]
-            if filename == "links.json":
-                links = file_data['body']['links']
-                load_links(links, bundle['uuid'])
-
-            self.register_dcp_metadata_schema_type(schema_type)
-            file_row = File(
-                uuid=file_data['uuid'],
-                version=file_data['version'],
-                content_type=file_data['content-type'],
-                size=file_data['size'],
-                extension=str(file_extension),
-                body=file_data['body'],
-                dcp_schema_type_name=schema_type
-            )
-
-            bf_links.append(BundleFileLink(bundle=bundle_row, file=file_row, name=filename))
-        config.db_session.add_all(bf_links)
 
 
 def update_process_join_table():
@@ -137,10 +40,6 @@ def update_process_join_table():
        ON CONFLICT DO NOTHING;
         """
     )
-    config.db_session.commit()
-
-
-def commit_to_db(extracted_bundles):
     config.db_session.commit()
 
 
@@ -198,64 +97,6 @@ def create_materialized_view_tables():
     update_files_materialized_view()
     create_dcp_schema_type_materialized_views(matviews)
     config.db_session.commit()
-
-
-def load_links(links, bundle_uuid):
-    for link in links:
-        try:
-            process = format_process_info(link)
-            config.db_session.add(Process(process_uuid=process['process_uuid']))
-            create_process_file_links(process)
-        except AssertionError as e:
-            logger.error(f"Error while loading link for bundle: {bundle_uuid} error: {e}")
-
-
-def format_process_info(link):
-    assert 'process' in link
-    process_uuid = link['process']
-    protocol_uuids = []
-    for protocol in link['protocols']:
-        protocol_uuid = protocol['protocol_id']
-        protocol_uuids.append(protocol_uuid)
-
-    return {"process_uuid": process_uuid, "input_file_uuids": link["inputs"], "output_file_uuids": link["outputs"],
-            "protocol_uuids": protocol_uuids}
-
-
-def create_process_file_links(process):
-    process_file_links = []
-    input_file_uuids = process['input_file_uuids']
-    output_file_uuids = process['output_file_uuids']
-    protocol_uuids = process['protocol_uuids']
-
-    for file_uuid in input_file_uuids:
-        process_file_links.append(
-            ProcessFileLink(
-                process_uuid=process['process_uuid'],
-                file_uuid=file_uuid,
-                process_file_connection_type='INPUT_ENTITY'
-            )
-        )
-
-    for file_uuid in output_file_uuids:
-        process_file_links.append(
-            ProcessFileLink(
-                process_uuid=process['process_uuid'],
-                file_uuid=file_uuid,
-                process_file_connection_type='OUTPUT_ENTITY'
-            )
-        )
-
-    for file_uuid in protocol_uuids:
-        process_file_links.append(
-            ProcessFileLink(
-                process_uuid=process['process_uuid'],
-                file_uuid=file_uuid,
-                process_file_connection_type='PROTOCOL_ENTITY'
-            )
-        )
-
-    config.db_session.add_all(process_file_links)
 
 
 def etl_one_bundle(bundle_uuid, bundle_version):

--- a/dcpquery/etl/load.py
+++ b/dcpquery/etl/load.py
@@ -1,0 +1,115 @@
+import logging
+import re
+
+from dcpquery import config
+from dcpquery.db import DCPMetadataSchemaType, Bundle, File, BundleFileLink, Process, ProcessFileLink
+logger = logging.getLogger(__name__)
+
+
+class BundleLoader:
+    def __init__(self):
+        schema_types = config.db_session.query(DCPMetadataSchemaType).with_entities(DCPMetadataSchemaType.name).all()
+        self.schema_types = [schema[0] for schema in schema_types]
+
+    def register_dcp_metadata_schema_type(self, schema_type):
+        if schema_type and schema_type not in self.schema_types:
+            schema = DCPMetadataSchemaType(name=schema_type)
+            config.db_session.add(schema)
+            self.schema_types.append(schema_type)
+
+    def load_bundle(self, bundle, extractor=None, transformer=None):
+        bf_links = []
+        bundle_row = Bundle(uuid=bundle["uuid"],
+                            version=bundle["version"],
+                            manifest=bundle["manifest"],
+                            aggregate_metadata=bundle["aggregate_metadata"])
+        for file_data in bundle["files"]:
+            filename = file_data.pop("name")
+            file_extension = get_file_extension(filename)
+            schema_type = None
+            if file_data['body']:
+                schema_type = file_data['body'].get('describedBy', '').split('/')[-1]
+            if filename == "links.json":
+                links = file_data['body']['links']
+                load_links(links, bundle['uuid'])
+
+            self.register_dcp_metadata_schema_type(schema_type)
+            file_row = File(
+                uuid=file_data['uuid'],
+                version=file_data['version'],
+                content_type=file_data['content-type'],
+                size=file_data['size'],
+                extension=str(file_extension),
+                body=file_data['body'],
+                dcp_schema_type_name=schema_type
+            )
+
+            bf_links.append(BundleFileLink(bundle=bundle_row, file=file_row, name=filename))
+        config.db_session.add_all(bf_links)
+
+
+def get_file_extension(filename):
+    try:
+        regex_search_result = re.search('^(?:(?:.){1,}?)((?:[.][a-z]{1,10}){1,2})$', filename)
+        file_extension = regex_search_result.group(1)
+    except AttributeError:
+        file_extension = None
+    return file_extension
+
+
+def load_links(links, bundle_uuid):
+    for link in links:
+        try:
+            process = format_process_info(link)
+            config.db_session.add(Process(process_uuid=process['process_uuid']))
+            create_process_file_links(process)
+        except AssertionError as e:
+            logger.error(f"Error while loading link for bundle: {bundle_uuid} error: {e}")
+
+
+def format_process_info(link):
+    assert 'process' in link
+    process_uuid = link['process']
+    protocol_uuids = []
+    for protocol in link['protocols']:
+        protocol_uuid = protocol['protocol_id']
+        protocol_uuids.append(protocol_uuid)
+
+    return {"process_uuid": process_uuid, "input_file_uuids": link["inputs"], "output_file_uuids": link["outputs"],
+            "protocol_uuids": protocol_uuids}
+
+
+def create_process_file_links(process):
+    process_file_links = []
+    input_file_uuids = process['input_file_uuids']
+    output_file_uuids = process['output_file_uuids']
+    protocol_uuids = process['protocol_uuids']
+
+    for file_uuid in input_file_uuids:
+        process_file_links.append(
+            ProcessFileLink(
+                process_uuid=process['process_uuid'],
+                file_uuid=file_uuid,
+                process_file_connection_type='INPUT_ENTITY'
+            )
+        )
+
+    for file_uuid in output_file_uuids:
+        process_file_links.append(
+            ProcessFileLink(
+                process_uuid=process['process_uuid'],
+                file_uuid=file_uuid,
+                process_file_connection_type='OUTPUT_ENTITY'
+            )
+        )
+
+    for file_uuid in protocol_uuids:
+        process_file_links.append(
+            ProcessFileLink(
+                process_uuid=process['process_uuid'],
+                file_uuid=file_uuid,
+                process_file_connection_type='PROTOCOL_ENTITY'
+            )
+        )
+
+    config.db_session.add_all(process_file_links)

--- a/dcpquery/etl/transform.py
+++ b/dcpquery/etl/transform.py
@@ -1,0 +1,51 @@
+import json
+import os
+import re
+from collections.__init__ import OrderedDict
+
+
+def transform_bundle(bundle_uuid, bundle_version, bundle_path, bundle_manifest_path, extractor=None):
+    """
+    This function is used with the ETL interface in dcplib.etl.DSSExtractor.extract.
+    Given a bundle ID and directory containing its medatata JSON files, it produces an intermediate representation
+    of the bundle and its files ready to be inserted into the database by BundleLoader.
+    """
+    result = dict(uuid=bundle_uuid,
+                  version=bundle_version,
+                  manifest=json.load(open(bundle_manifest_path)),
+                  aggregate_metadata={},
+                  files=OrderedDict())
+    # Load and process all the metadata files; construct the "aggregate_metadata" doc:
+    # - Singleton metadata files get inserted under their name minus the extension (project.json => {"project": {...}})
+    # - Numbered metadata files are put in an array (assay_0.json, assay_1.json => {"assay": [{...0...}, {...1...}]})
+    bundle_fetched_files = sorted(os.listdir(bundle_path)) if os.path.exists(bundle_path) else []
+    for f in bundle_fetched_files:
+        if re.match(r"(.+)_(\d+).json", f):
+            metadata_key, index = re.match(r"(.+)_(\d+).json", f).groups()
+        elif re.match(r"(.+).json", f):
+            metadata_key, index = re.match(r"(.+).json", f).group(1), None
+        else:
+            metadata_key, index = f, None
+        with open(os.path.join(bundle_path, f)) as fh:
+            file_doc = json.load(fh)
+            if index is None:
+                result["aggregate_metadata"][metadata_key] = file_doc
+            else:
+                result["aggregate_metadata"].setdefault(metadata_key, [])
+                result["aggregate_metadata"][metadata_key].append(file_doc)
+        for fm in result["manifest"]["files"]:
+            if f == fm["name"] and "schema_type" in file_doc:
+                result["files"][fm["name"]] = dict(fm,
+                                                   body=file_doc,
+                                                   schema_type=file_doc['schema_type'])
+    # For all other (non-metadata) files from the bundle manifest, insert them with a default body
+    # indicating an empty schema type.
+    for fm in result["manifest"]["files"]:
+        if fm["name"] not in result["files"]:
+            result["files"][fm["name"]] = dict(fm,
+                                               body=None,
+                                               schema_type=None)
+
+    # Flatten the file list while preserving order.
+    result["files"] = list(result["files"].values())
+    return result

--- a/scripts/etl.sh
+++ b/scripts/etl.sh
@@ -15,11 +15,9 @@ apt-get install -qqy --no-install-suggests --no-install-recommends jq moreutils 
 
 virtualenv --python=python3 .venv
 source .venv/bin/activate
-rm -rf query-service
-export GIT_DISCOVERY_ACROSS_FILESYSTEM=1
-git clone https://github.com/HumanCellAtlas/query-service.git
-cd query-service
-#git checkout BRANCH_NAME # uncomment out to use a branch other than master
+cd query-service || git clone --depth 1 https://github.com/HumanCellAtlas/query-service.git cd query-service
+git fetch
+git checkout dunitz-json-flattening # uncomment out to use a branch other than master
 pip install --quiet -r requirements-dev.txt
 
 source environment # set to env scripts/launch_etl_job.sh called in

--- a/scripts/etl.sh
+++ b/scripts/etl.sh
@@ -11,15 +11,19 @@ cd /mnt
 export AWS_DEFAULT_REGION=us-east-1 DEBIAN_FRONTEND=noninteractive LC_ALL=C.UTF-8 LANG=C.UTF-8
 source /etc/profile
 
-apt-get install -qqy --no-install-suggests --no-install-recommends jq moreutils gettext make virtualenv zip unzip httpie git xz-utils
+apt-get install -qqy --no-install-suggests --no-install-recommends jq moreutils gettext make virtualenv zip unzip httpie git xz-utils dstat
 
 virtualenv --python=python3 .venv
 source .venv/bin/activate
-[[ -d query-service/.git ]] || git clone --depth 1 https://github.com/HumanCellAtlas/query-service.git
+rm -rf query-service
+export GIT_DISCOVERY_ACROSS_FILESYSTEM=1
+git clone https://github.com/HumanCellAtlas/query-service.git
 cd query-service
+git checkout dunitz-projects-migration-2
 pip install --quiet -r requirements-dev.txt
 
 source environment
+#export DSS_HOST='manually set url"
 S3_CACHE_URL=s3://${SERVICE_S3_BUCKET}/etl/cache.xz
 aws s3 cp $S3_CACHE_URL - | tar -xJ || true
 scripts/db_ctl load --db remote

--- a/scripts/etl.sh
+++ b/scripts/etl.sh
@@ -15,9 +15,12 @@ apt-get install -qqy --no-install-suggests --no-install-recommends jq moreutils 
 
 virtualenv --python=python3 .venv
 source .venv/bin/activate
-cd query-service || git clone --depth 1 https://github.com/HumanCellAtlas/query-service.git cd query-service
-git fetch
-git checkout dunitz-json-flattening # uncomment out to use a branch other than master
+if [ ! -d query-service ]; then
+git clone https://github.com/HumanCellAtlas/query-service.git
+fi
+cd query-service
+#git fetch # uncomment out to use a branch other than master
+#git checkout dunitz-json-flattening # uncomment out to use a branch other than master
 pip install --quiet -r requirements-dev.txt
 
 source environment # set to env scripts/launch_etl_job.sh called in

--- a/scripts/etl.sh
+++ b/scripts/etl.sh
@@ -11,7 +11,7 @@ cd /mnt
 export AWS_DEFAULT_REGION=us-east-1 DEBIAN_FRONTEND=noninteractive LC_ALL=C.UTF-8 LANG=C.UTF-8
 source /etc/profile
 
-apt-get install -qqy --no-install-suggests --no-install-recommends jq moreutils gettext make virtualenv zip unzip httpie git xz-utils dstat
+apt-get install -qqy --no-install-suggests --no-install-recommends jq moreutils gettext make virtualenv zip unzip httpie git xz-utils
 
 virtualenv --python=python3 .venv
 source .venv/bin/activate
@@ -19,10 +19,10 @@ rm -rf query-service
 export GIT_DISCOVERY_ACROSS_FILESYSTEM=1
 git clone https://github.com/HumanCellAtlas/query-service.git
 cd query-service
-git checkout dunitz-projects-migration-2
+#git checkout BRANCH_NAME # uncomment out to use a branch other than master
 pip install --quiet -r requirements-dev.txt
 
-source environment
+source environment # set to env scripts/launch_etl_job.sh called in
 #export DSS_HOST='manually set url"
 S3_CACHE_URL=s3://${SERVICE_S3_BUCKET}/etl/cache.xz
 aws s3 cp $S3_CACHE_URL - | tar -xJ || true

--- a/scripts/launch_etl_job.sh
+++ b/scripts/launch_etl_job.sh
@@ -5,9 +5,11 @@
 
 set -euo pipefail
 
-VCPUS=4
+VCPUS=8
+MEMORY_MB=16000
 worker_iam_policy_file="iam/policy-templates/${APP_NAME}-lambda.json"
 worker_iam_policy="${APP_NAME}-${STAGE}-etl-worker"
 ENSURE_POLICY="import sys, json; from aegea.util.aws import ensure_iam_role, IAMPolicyBuilder as pb; ensure_iam_role('$worker_iam_policy', policies=[pb(json.load(sys.stdin))], trust=['batch'])"
 cat "$worker_iam_policy_file" | envsubst | python -c "$ENSURE_POLICY"
-aegea batch submit --job-role $worker_iam_policy --mount-instance-storage --vcpus $VCPUS --execute ${APP_HOME}/scripts/etl.sh --environment STAGE=$STAGE --watch
+#aegea batch submit --job-role $worker_iam_policy --mount-instance-storage --vcpus $VCPUS --execute ${APP_HOME}/scripts/etl.sh --environment STAGE=$STAGE --watch
+aegea batch submit --job-role $worker_iam_policy --mount-instance-storage --vcpus $VCPUS --memory-mb $MEMORY_MB --execute ${APP_HOME}/scripts/etl.sh --environment STAGE=$STAGE --watch

--- a/scripts/launch_etl_job.sh
+++ b/scripts/launch_etl_job.sh
@@ -5,11 +5,10 @@
 
 set -euo pipefail
 
-VCPUS=8
-MEMORY_MB=16000
 worker_iam_policy_file="iam/policy-templates/${APP_NAME}-lambda.json"
 worker_iam_policy="${APP_NAME}-${STAGE}-etl-worker"
 ENSURE_POLICY="import sys, json; from aegea.util.aws import ensure_iam_role, IAMPolicyBuilder as pb; ensure_iam_role('$worker_iam_policy', policies=[pb(json.load(sys.stdin))], trust=['batch'])"
 cat "$worker_iam_policy_file" | envsubst | python -c "$ENSURE_POLICY"
-#aegea batch submit --job-role $worker_iam_policy --mount-instance-storage --vcpus $VCPUS --execute ${APP_HOME}/scripts/etl.sh --environment STAGE=$STAGE --watch
+VCPUS=16
+MEMORY_MB=16000
 aegea batch submit --job-role $worker_iam_policy --mount-instance-storage --vcpus $VCPUS --memory-mb $MEMORY_MB --execute ${APP_HOME}/scripts/etl.sh --environment STAGE=$STAGE --watch

--- a/tests/unit/test_create_async_query.py
+++ b/tests/unit/test_create_async_query.py
@@ -35,7 +35,7 @@ class TestCreateAsyncQuery(unittest.TestCase):
         )
 
     @patch("dcpquery.api.query_jobs.set_job_status")
-    def xtest_process_async_query_with_invalid_query(self, set_job_status):
+    def test_process_async_query_with_invalid_query(self, set_job_status):
         config.db_statement_timeout_seconds = 880
         body = json.dumps(dict(query="SELECT * FROM NONEXISTENT_TABLE", params={}))
         process_async_query(dict(self.mock_event_record, body=body))

--- a/tests/unit/test_create_async_query.py
+++ b/tests/unit/test_create_async_query.py
@@ -35,7 +35,7 @@ class TestCreateAsyncQuery(unittest.TestCase):
         )
 
     @patch("dcpquery.api.query_jobs.set_job_status")
-    def test_process_async_query_with_invalid_query(self, set_job_status):
+    def xtest_process_async_query_with_invalid_query(self, set_job_status):
         config.db_statement_timeout_seconds = 880
         body = json.dumps(dict(query="SELECT * FROM NONEXISTENT_TABLE", params={}))
         process_async_query(dict(self.mock_event_record, body=body))

--- a/tests/unit/test_database_orm.py
+++ b/tests/unit/test_database_orm.py
@@ -2,7 +2,8 @@ import time
 import unittest
 
 from dcpquery.db import Bundle, BundleFileLink, Process, File
-from dcpquery.etl import load_links, update_process_join_table
+from dcpquery.etl import update_process_join_table
+from dcpquery.etl.load import load_links
 from tests import vx_bundle, vx_bf_links, vx_bundle_aggregate_md, mock_links
 
 from dcpquery import config

--- a/tests/unit/test_etl.py
+++ b/tests/unit/test_etl.py
@@ -5,7 +5,7 @@ from dcpquery.etl.load import load_links
 
 
 class TestETLHelpers(unittest.TestCase):
-    @patch('dcpquery.etl.logger.error')
+    @patch('dcpquery.etl.load.logger.error')
     def test_links_ignore_unknown_format(self, logger):
         load_links([{1: 2}], 'mock_bundle_uuid')
         logger.assert_called_once()

--- a/tests/unit/test_etl.py
+++ b/tests/unit/test_etl.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import patch
 
-from dcpquery.etl import load_links
+from dcpquery.etl.load import load_links
 
 
 class TestETLHelpers(unittest.TestCase):

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -7,7 +7,8 @@ from dcpquery.db import Bundle, DCPMetadataSchemaType
 
 from tests import (vx_bundle, vx_bundle_uuid, vx_bundle_version, vx_bundle_manifest, vx_bundle_aggregate_md, mock_links,
                    load_fixture)
-from dcpquery.etl import load_links, create_process_file_links, BundleLoader, dcpquery_etl_finalizer
+from dcpquery.etl import BundleLoader, dcpquery_etl_finalizer
+from dcpquery.etl.load import load_links, create_process_file_links
 
 
 class TestPostgresLoader(unittest.TestCase):

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -3,12 +3,11 @@ import json, unittest, secrets
 from unittest.mock import patch
 
 from dcpquery import config
-from dcpquery.db import Bundle, DCPMetadataSchemaType
+from dcpquery.db import Bundle
+from dcpquery.etl import BundleLoader
+from dcpquery.etl.load import create_process_file_links
 
-from tests import (vx_bundle, vx_bundle_uuid, vx_bundle_version, vx_bundle_manifest, vx_bundle_aggregate_md, mock_links,
-                   load_fixture)
-from dcpquery.etl import BundleLoader, dcpquery_etl_finalizer
-from dcpquery.etl.load import load_links, create_process_file_links
+from tests import vx_bundle, vx_bundle_uuid, vx_bundle_version, vx_bundle_manifest, vx_bundle_aggregate_md, load_fixture
 
 
 class TestPostgresLoader(unittest.TestCase):
@@ -52,7 +51,7 @@ class TestPostgresLoader(unittest.TestCase):
         self.assertDictEqual(result[0].aggregate_metadata, vx_bundle_aggregate_md)
 
     @patch('dcpquery.config.db_session.add_all')
-    @patch('dcpquery.etl.ProcessFileLink', )
+    @patch('dcpquery.etl.load.ProcessFileLink', )
     def test_create_processes_calls_insert_correct_number_times(self, mock_process_file_link, mock_add_all):
         mock_process = {'process_uuid': 'a0000006-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
                         'input_file_uuids': ["b0000011-aaaa-aaaa-aaaa-aaaaaaaaaaaa",

--- a/tests/unit/test_transform.py
+++ b/tests/unit/test_transform.py
@@ -1,7 +1,8 @@
 import os, sys, json, copy, shutil, unittest
 from tempfile import TemporaryDirectory
 
-from dcpquery.etl import transform_bundle, format_process_info, get_file_extension
+from dcpquery.etl import transform_bundle
+from dcpquery.etl.load import get_file_extension, format_process_info
 from tests import vx_bundle, load_fixture, mock_links, vx_bundle_uuid, vx_bundle_version
 
 


### PR DESCRIPTION
- updates to ETL batch script runner 
- Break up ETL file, pull out load and transform functions to make it more clear

## Testing
- tested batch script runner to rerun etl jobs in dev/integration/staging

## Todo/questions
- would further refactoring of the etl functions be useful? Are there any sections that seem overly dense or confusing?