### PR TITLE
Format all exceptions in RFC 7807 style

### DIFF
--- a/dcpquery/api/__init__.py
+++ b/dcpquery/api/__init__.py
@@ -1,10 +1,11 @@
-import os, sys, re, json, collections, logging, datetime, uuid, gzip
+import os, sys, re, json, collections, logging, datetime, uuid, gzip, traceback
 from decimal import Decimal
 
 import requests, connexion, chalice, brotli
 from sqlalchemy.engine.result import RowProxy
 from connexion.resolver import RestyResolver
 from connexion.lifecycle import ConnexionResponse
+from connexion.exceptions import ProblemException
 from werkzeug.http import parse_accept_header
 
 
@@ -59,11 +60,19 @@ class ChaliceWithConnexion(chalice.Chalice):
         for route, methods in routes.items():
             self.route(route, methods=list(set(methods) - {"OPTIONS"}), cors=True)(self.dispatch)
 
+    def render_internal_error(self, error):
+        return self.connexion_app.common_error_handler(ProblemException(
+            status=requests.codes.internal_server_error,
+            title=repr(error),
+            detail=traceback.format_exc() if self.debug else None
+        ))
+
     def create_connexion_app(self):
         app = connexion.App(self.app_name)
         app.app.json_encoder = JSONEncoder
         resolver = RestyResolver(self.app_name + '.api', collection_endpoint_name="list")
         app.add_api(self.swagger_spec_path, resolver=resolver, validate_responses=True, arguments=os.environ)
+        app.add_error_handler(Exception, self.render_internal_error)
         return app
 
     def dispatch(self, *args, **kwargs):


### PR DESCRIPTION
Previously, any exception not subclassing
connexion.exceptions.ProblemException would be rendered in plain
text. This is not ideal for clients that make the assumption that all
responses are JSON-formatted (including our own query builder UI).

Install a global error handler that formats exceptions as a JSON HTTP
500 response. This roughly matches dss.DSSApp.common_error_handler in
https://github.com/HumanCellAtlas/data-store/blob/master/dss/__init__.py
(but is hopefully simpler).